### PR TITLE
Changing port, and starting bots *after* match start

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -248,14 +248,19 @@ def on_websocket_close(page, sockets):
 
 
 def is_chrome_installed():
-    return eel.browsers.chr.get_instance_path() is not None
+    if hasattr(eel.browsers, 'chr'):
+        return eel.browsers.chr.get_instance_path() is not None
+    else:
+        return eel.browsers.chm.get_instance_path() is not None
 
 
 def start():
     gui_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'gui')
     eel.init(gui_folder)
 
-    options = {}
+    # Ultra rare port, unlikely to conflict with other programs.
+    # options = {'port': 51993}
+    options = {'port': 51993}
     if not is_chrome_installed():
         options = {'mode': 'system-default'}  # Use the system default browser if the user doesn't have chrome.
 

--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -60,8 +60,8 @@ def start_match_helper(bot_list, match_settings):
     sm.load_match_config(match_config)
     sm.launch_ball_prediction()
     sm.launch_quick_chat_manager()
-    sm.launch_bot_processes()
     sm.start_match()
+    sm.launch_bot_processes()
     # Note that we are not calling infinite_loop because that is not compatible with the way eel works!
     # Instead we will reproduce the important behavior from infinite_loop inside this file.
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.13'
+__version__ = '0.0.14'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
The new port will make us less likely to conflict with other programs. The old one was port 8000 which is very common.

Starting bots after starting the match is the new way of doing things in rlbot 1.15.7, and it will make Self-Driving Car start working.