### PR TITLE
 Making the bot pack clobber the previous folder, fixing bugs in bot creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,8 +180,8 @@ typings/
 # FuseBox cache
 .fusebox/
 
-#DynamoDB Local files 
-.dynamodb/ 
+#DynamoDB Local files
+.dynamodb/
 
 .idea/
 .vscode/
@@ -190,3 +190,5 @@ typings/
 RLBotPack.zip
 github-bot-pack.zip
 RLBotPack/
+RLBotPackDeletable/
+MyBots/

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -1,23 +1,35 @@
-from pathlib import Path
+import os
+import tempfile
 import urllib
 import zipfile
+from pathlib import Path
+from shutil import rmtree
 
 
-def download_and_extract_zip(download_url: str, local_zip_path: Path, local_folder_path: Path):
-    urllib.request.urlretrieve(download_url, local_zip_path)
+def download_and_extract_zip(download_url: str, local_folder_path: Path, clobber: bool = False):
+    """
+    :param clobber: If true, we will delete anything found in local_folder_path.
+    :return:
+    """
 
-    with zipfile.ZipFile(local_zip_path, 'r') as zip_ref:
-        zip_ref.extractall(local_folder_path)
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        downloadedZip = os.path.join(tmpdirname, 'downloaded.zip')
+        urllib.request.urlretrieve(download_url, downloadedZip)
+
+        if clobber and os.path.exists(local_folder_path):
+            rmtree(local_folder_path)
+
+        with zipfile.ZipFile(downloadedZip, 'r') as zip_ref:
+            zip_ref.extractall(local_folder_path)
 
 
 def download_gitlfs(repo_url: str, checkout_folder: Path, branch_name: str):
     print('Starting download of a git repo... this might take a while.')
-    
+
     # Download the most of the files eg. https://github.com/RLBot/RLBotPack/archive/master.zip
     download_and_extract_zip(
         download_url=repo_url + '/archive/' + branch_name + '.zip',
-        local_zip_path='github-bot-pack.zip',
-        local_folder_path=checkout_folder)
+        local_folder_path=checkout_folder, clobber=True)
 
     repo_extraction_name = '/' + repo_url.split('/')[-1] + '-' + branch_name + '/'
 

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -18,7 +18,8 @@ from rlbot_gui.bot_management.downloader import download_gitlfs
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, do_infinite_loop_content
 
 DEFAULT_BOT_FOLDER = 'default_bot_folder'
-RLBOTPACK_FOLDER = "RLBotPackDeletable"
+BOTPACK_FOLDER = 'RLBotPackDeletable'
+OLD_BOTPACK_FOLDER = 'RLBotPack'
 CREATED_BOTS_FOLDER = 'MyBots'
 BOT_FOLDER_SETTINGS_KEY = 'bot_folder_settings'
 settings = QSettings('rlbotgui', 'preferences')
@@ -211,10 +212,16 @@ def download_bot_pack():
     # The bot pack in now hosted at https://github.com/RLBot/RLBotPack
     download_gitlfs(
         repo_url="https://github.com/RLBot/RLBotPack",
-        checkout_folder=RLBOTPACK_FOLDER,
+        checkout_folder=BOTPACK_FOLDER,
         branch_name='master')
 
-    bot_folder_settings['folders'][os.path.abspath(RLBOTPACK_FOLDER)] = {'visible': True}
+    # Configure the folder settings.
+    bot_folder_settings['folders'][os.path.abspath(BOTPACK_FOLDER)] = {'visible': True}
+
+    if bot_folder_settings['folders'][os.path.abspath(OLD_BOTPACK_FOLDER)]:
+        # Toggle off the old one since it's been replaced.
+        bot_folder_settings['folders'][os.path.abspath(OLD_BOTPACK_FOLDER)] = {'visible': False}
+
     settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
     settings.sync()
 

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -69,24 +69,24 @@
 						</md-button>
 
 						<md-menu-content>
-							<md-menu-item @click="pickBotConfig()">
-								<span>File</span>
-								<md-icon>file_copy</md-icon>
-							</md-menu-item>
-							<md-menu-item  @click="pickBotFolder()">
-								<span>Folder</span>
-								<md-icon>folder_open</md-icon>
-							</md-menu-item>
 							<md-menu-item  @click="downloadBotPack()">
 								<span>Download Bot Pack</span>
 								<md-icon>cloud_download</md-icon>
 							</md-menu-item>
+							<md-menu-item  @click="showNewBotDialog = true">
+								<span>Start Your Own Bot!</span>
+								<md-icon>create</md-icon>
+							</md-menu-item>
+							<md-menu-item  @click="pickBotFolder()">
+								<span>Load Folder</span>
+								<md-icon>folder_open</md-icon>
+							</md-menu-item>
+							<md-menu-item @click="pickBotConfig()">
+								<span>Load Cfg File</span>
+								<md-icon>file_copy</md-icon>
+							</md-menu-item>
 						</md-menu-content>
 					</md-menu>
-					<md-button class="md-fab md-mini bot-pool-adder" @click="showNewBotDialog = true">
-						<md-icon>create</md-icon>
-						<md-tooltip md-direction="top">Begin a new bot!</md-tooltip>
-					</md-button>
 					<md-button class="md-fab md-mini bot-pool-adder" @click="showFolderSettingsDialog = true">
 						<md-icon>settings</md-icon>
 						<md-tooltip md-direction="top">Manage bot folders</md-tooltip>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.17'
+__version__ = '0.0.18'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
### Bot Pack
Bot pack problem: the GUI currently extracts the bot pack and merges the files into the existing bot pack. That could lead to bad consequences:
- Removing a bot from the bot pack won't work
- Renaming a bot in the bot pack will result in both the old and new version being present
- Merging the files could result in broken bots

Complication: It's not safe to clobber the current 'RLBotPack' folder because users could have stored their own bot files there. This is more likely than you think:
- When you download the bot pack, RLBotPack becomes the 'default bot folder'.
- When you choose the 'create new bot' feature, it gets initialized in the default bot folder.

We don't want to delete anybody's stuff, so I'm making a **new** bot pack location called RLBotPackDeletable. RLBotPack will be left alone, and RLBotPackDeletable becomes a folder we're comfortable deleting because of its name and because, going forward, new bots will be initialized in a special 'MyBots' folder.

### Create New Bot
Certain aspects of it had become broken. Fixed now.