### PR TITLE
Adding ability to create new scratch bot.

### DIFF
--- a/rlbot_gui/bot_management/bot_creation.py
+++ b/rlbot_gui/bot_management/bot_creation.py
@@ -1,5 +1,6 @@
 import fileinput
 import os
+import random
 import re
 import string
 import sys
@@ -72,5 +73,45 @@ def bootstrap_python_bot(bot_name, directory):
     # This is intended to open the example python file in the default system editor for .py files.
     # Hopefully this will be VS Code or notepad++ or something. If it gets executed as a python script, no harm done.
     os.startfile(python_file)
+
+    return config_file
+
+
+def bootstrap_scratch_bot(bot_name, directory):
+    sanitized_name = convert_to_filename(bot_name)
+    bot_directory = Path(directory or '.')
+    top_dir = bot_directory / sanitized_name
+    if os.path.exists(top_dir):
+        raise FileExistsError(f'There is already a bot named {sanitized_name}, please choose a different name!')
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdir = Path(tmpdirname)
+        print('created temporary directory', tmpdir)
+
+        download_and_extract_zip(
+            download_url='https://github.com/RLBot/RLBotScratchInterface/archive/gui-friendly.zip',
+            local_folder_path=tmpdir)
+
+        safe_move(tmpdir / 'RLBotScratchInterface-gui-friendly', top_dir)
+
+    # Choose appropriate file names based on the bot name
+    code_dir = top_dir / sanitized_name
+    sb3_filename = f'{sanitized_name}.sb3'
+    sb3_file = code_dir / sb3_filename
+    config_filename = f'{sanitized_name}.cfg'
+    config_file = code_dir / config_filename
+
+    replace_all(top_dir / 'rlbot.cfg', r'(participant_config_\d = ).*$',
+                r'\1' + os.path.join(sanitized_name, config_filename).replace('\\', '\\\\'))
+
+    # We're assuming that the file structure / names in RLBotScratchInterface will not change.
+    # Semi-safe assumption because we're looking at a gui-specific git branch which ought to be stable.
+    safe_move(top_dir / 'scratch_bot', code_dir)
+    safe_move(code_dir / 'my_scratch_bot.sb3', sb3_file)
+    safe_move(code_dir / 'my_scratch_bot.cfg', config_file)
+
+    replace_all(config_file, r'name = .*$', 'name = ' + bot_name)
+    replace_all(config_file, r'sb3file = .*$', 'sb3file = ' + sb3_filename)
+    replace_all(config_file, r'port = .*$', 'port = ' + str(random.randint(20000, 65000)))
 
     return config_file

--- a/rlbot_gui/gui/js/main.js
+++ b/rlbot_gui/gui/js/main.js
@@ -124,6 +124,11 @@ const app = new Vue({
                 app.showProgressSpinner = true;
                 eel.begin_python_bot(bot_name)(botLoadHandler);
             }
+
+            if (language === 'scratch') {
+                app.showProgressSpinner = true;
+                eel.begin_scratch_bot(bot_name)(botLoadHandler);
+            }
         },
         applyFolderSettings: function() {
             eel.save_folder_settings(app.folderSettings);

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -313,6 +313,7 @@
 					</md-field>
 					<div>
 						<md-radio v-model="newBotLanguageChoice" value="python">Python</md-radio>
+						<md-radio v-model="newBotLanguageChoice" value="scratch">Scratch</md-radio>
 					</div>
 				</md-dialog-content>
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.23'
+__version__ = '0.0.24'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
- Pulls from https://github.com/RLBot/RLBotScratchInterface/tree/gui-friendly
- Installs webdriver_manager (needed to run scratch bot)
- Respects the user's bot name
- Picks a random port to avoid collisions with other users' bots
