### PR TITLE
Showing bot logos on the info card.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ github-bot-pack.zip
 RLBotPack/
 RLBotPackDeletable/
 MyBots/
+rlbot_gui/gui/imgs/logos

--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -138,14 +138,17 @@ body {
 .bot-card img {
   height: 1.5rem;
   margin: 3px;
+}
+
+.bot-card img.darkened {
   filter: brightness(50%);
 }
 
-.org .bot-card img {
+.org .bot-card img.darkened {
   filter: brightness(0%) invert(50%) sepia(25%) saturate(7482%) hue-rotate(350deg) brightness(102%) contrast(90%);
 }
 
-.blu .bot-card img {
+.blu .bot-card img.darkened {
   filter: brightness(0%) invert(17%) sepia(78%) saturate(3372%) hue-rotate(198deg) brightness(96%) contrast(101%);
 }
 
@@ -198,7 +201,19 @@ body {
 }
 
 .bot-file-path {
-  color: #717171;
-  font-size: 10pt;
+  color: #939393;
+  font-size: 9pt;
   font-weight: normal;
+}
+
+.bot-logo {
+  float:right;
+  margin-left: 10px;
+  margin-top: 15px;
+  margin-bottom: 10px;
+  max-width: 250px;
+}
+
+.md-dialog{
+  width:80%;
 }

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -96,7 +96,8 @@
 				<draggable v-model="botPool" :options="{group: {name:'bots', pull:'clone', put:false}, sort: false}">
 					<md-card class="bot-card md-elevation-3" v-for="bot in botPool" >
 						<button class="center-flex secret-button" @click="addToTeam(bot, teamSelection)">
-							<img v-bind:src="bot.image">
+							<img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
+							<img v-if="bot.logo" v-bind:src="bot.logo">
 							<span class="bot-name">{{ bot.name }}</span>
 							<md-button class="md-icon-button md-dense warning-icon" v-if="bot.warn"
 									   @click.stop="activeBot = bot; showLanguageWarning = true;">
@@ -126,7 +127,8 @@
 						</md-card-header>
 						<draggable v-model="blueTeam" class="team-entries" :options="{group:'bots'}">
 							<md-card class="bot-card center-flex md-elevation-3" v-for="(bot, index) in blueTeam">
-								<img v-bind:src="bot.image">
+								<img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
+								<img v-if="bot.logo" v-bind:src="bot.logo">
 								<span class="bot-name">{{ bot.name }}</span>
 								<md-button class="md-icon-button" @click="blueTeam.splice(index, 1)">
 									<md-icon>close</md-icon>
@@ -143,7 +145,8 @@
 						</md-card-header>
 						<draggable v-model="orangeTeam" class="team-entries" :options="{group:'bots'}">
 							<md-card class="bot-card center-flex md-elevation-3" v-for="(bot, index) in orangeTeam">
-								<img v-bind:src="bot.image">
+								<img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
+								<img v-if="bot.logo" v-bind:src="bot.logo">
 								<span class="bot-name">{{ bot.name }}</span>
 								<md-button class="md-icon-button" @click="orangeTeam.splice(index, 1)">
 									<md-icon>close</md-icon>
@@ -255,17 +258,17 @@
 
 			<md-dialog v-if="activeBot && activeBot.info" :md-active.sync="showBotInfo">
 				<md-dialog-title>
-					{{activeBot.name}}<br />
-					<span class="bot-file-path">{{activeBot.path}}</span>
+					{{activeBot.name}}
 				</md-dialog-title>
 				<md-dialog-content>
-
+					<img v-if="activeBot.logo" class="bot-logo" v-bind:src="activeBot.logo">
 					<p><span class="bot-info-key">Developers:</span> {{activeBot.info.developer}}</p>
 					<p><span class="bot-info-key">Description:</span> {{activeBot.info.description}}</p>
 					<p><span class="bot-info-key">Fun Fact:</span> {{activeBot.info.fun_fact}}</p>
 					<p><span class="bot-info-key">GitHub:</span>
 						<a :href="activeBot.info.github" target="_blank">{{activeBot.info.github}}</a></p>
 					<p><span class="bot-info-key">Language:</span> {{activeBot.info.language}}</p>
+					<p class="bot-file-path">{{activeBot.path}}</p>
 				</md-dialog-content>
 
 				<md-dialog-actions>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.24'
+__version__ = '0.0.25'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
People can configure bot logos now, either by putting a logo.png next to their bot cfg file, or specifying `logo_file = ...` in their bot cfg like this:

```
[Locations]
looks_config = ./atba_looks.cfg
python_file = atba.py
logo_file = my_logo.png
name = AlwaysTowardsBallAgent
```

![image](https://user-images.githubusercontent.com/575644/62414465-89b9f000-b5d0-11e9-86aa-c0ac43f0e68f.png)


![image](https://user-images.githubusercontent.com/575644/62414460-80c91e80-b5d0-11e9-9611-f266061010aa.png)
