### PR TITLE
Remember last match & team settings.

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -23,6 +23,8 @@ BOTPACK_FOLDER = 'RLBotPackDeletable'
 OLD_BOTPACK_FOLDER = 'RLBotPack'
 CREATED_BOTS_FOLDER = 'MyBots'
 BOT_FOLDER_SETTINGS_KEY = 'bot_folder_settings'
+MATCH_SETTINGS_KEY = 'match_settings'
+TEAM_SETTINGS_KEY = 'team_settings'
 settings = QSettings('rlbotgui', 'preferences')
 
 bot_folder_settings = settings.value(BOT_FOLDER_SETTINGS_KEY, type=dict)
@@ -100,6 +102,47 @@ def save_folder_settings(folder_settings):
     bot_folder_settings = folder_settings
     settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
     settings.sync()
+
+
+def validate_bots(bots):
+    '''Reload rlbot controlled bot bundles and remove invalid ones'''
+    valid_bots = []
+
+    for bot in bots:
+        if bot["type"] in ('rlbot', 'party_member_bot'):
+            valid_bots += load_bundle(bot["path"])
+        else:
+            valid_bots.append(bot)
+
+    return valid_bots
+
+
+@eel.expose
+def get_match_settings():
+    match_settings = settings.value(MATCH_SETTINGS_KEY, type=dict)
+    return match_settings if match_settings else None
+
+
+@eel.expose
+def get_team_settings():
+    team_settings = settings.value(TEAM_SETTINGS_KEY, type=dict)
+    if not team_settings:
+        return None
+
+    return {
+        "blue_team": validate_bots(team_settings["blue_team"]),
+        "orange_team": validate_bots(team_settings["orange_team"])
+    }
+
+
+@eel.expose
+def save_match_settings(match_settings):
+    settings.setValue(MATCH_SETTINGS_KEY, match_settings)
+
+
+@eel.expose
+def save_team_settings(blue_bots, orange_bots):
+    settings.setValue(TEAM_SETTINGS_KEY, {"blue_team" : blue_bots, "orange_team": orange_bots})
 
 
 def pick_bot_location(is_folder):

--- a/rlbot_gui/gui/js/main.js
+++ b/rlbot_gui/gui/js/main.js
@@ -69,6 +69,9 @@ const app = new Vue({
     },
     methods: {
         startMatch: function (event) {
+            eel.save_match_settings(this.matchSettings);
+            eel.save_team_settings(this.blueTeam, this.orangeTeam);
+
             const blueBots = this.blueTeam.map((bot) => { return  {'name': bot.name, 'team': 0, 'type': bot.type, 'skill': bot.skill, 'path': bot.path} });
             const orangeBots = this.orangeTeam.map((bot) => { return  {'name': bot.name, 'team': 1, 'type': bot.type, 'skill': bot.skill, 'path': bot.path} });
             eel.start_match(blueBots.concat(orangeBots), this.matchSettings);
@@ -97,6 +100,17 @@ const app = new Vue({
                 const mutatorName = mutator.replace('_types', '');
                 self.matchSettings.mutators[mutatorName] = self.matchOptions.mutators[mutator][0];
             });
+        },
+        resetMatchSettingsToDefault: function() {
+            this.matchSettings.map = this.matchOptions.map_types[0];
+            this.matchSettings.game_mode = this.matchOptions.game_modes[0];
+            this.matchSettings.match_behavior = this.matchOptions.match_behaviours[0];
+            this.matchSettings.skip_replays = false;
+            this.matchSettings.instant_start = false;
+            this.matchSettings.enable_lockstep = false;
+            this.resetMutatorsToDefault();
+        
+            this.updateBGImage(this.matchSettings.map);
         },
         updateBGImage: function(mapName) {
             this.bodyStyle = { backgroundImage: "url(../imgs/arenas/" + mapName + ".jpg)" };
@@ -142,6 +156,8 @@ const app = new Vue({
 eel.get_folder_settings()(folderSettingsReceived);
 eel.scan_for_bots()(botsReceived);
 eel.get_match_options()(matchOptionsReceived);
+eel.get_match_settings()(matchSettingsReceived);
+eel.get_team_settings()(teamSettingsReceived);
 
 eel.get_language_support()((support) => {
     app.languageSupport = support;
@@ -196,14 +212,22 @@ function applyLanguageWarnings() {
 
 function matchOptionsReceived(matchOptions) {
     app.matchOptions = matchOptions;
+}
 
-    app.matchSettings.map = app.matchOptions.map_types[0];
-    app.matchSettings.game_mode = app.matchOptions.game_modes[0];
-    app.matchSettings.match_behavior = app.matchOptions.match_behaviours[0];
+function matchSettingsReceived(matchSettings) {
+    if (matchSettings) {
+        app.matchSettings = matchSettings;
+        app.updateBGImage(app.matchSettings.map);
+    } else {
+        app.resetMatchSettingsToDefault();
+    }
+}
 
-    app.updateBGImage(app.matchSettings.map);
-
-    app.resetMutatorsToDefault();
+function teamSettingsReceived(teamSettings) {
+    if (teamSettings) {
+        app.blueTeam = teamSettings.blue_team;
+        app.orangeTeam = teamSettings.orange_team;
+    }
 }
 
 function folderSettingsReceived(folderSettings) {

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -34,6 +34,9 @@
 							<md-menu-item @click="showPackageInstaller = true;">
 								Install missing python package
 							</md-menu-item>
+							<md-menu-item @click="resetMatchSettingsToDefault()">
+								Reset match settings
+							</md-menu-item>
 						</md-menu-content>
 					</md-menu>
 				</div>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.28'
+__version__ = '0.0.29'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
This makes the GUI save match settings and team settings when a match is started, and load them on the next startup.
If a bot is no longer valid (`load_bundle` fails), it disappears.