### PR TITLE
Download progress bar and checking for botpack updates

### DIFF
--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -1,12 +1,17 @@
 import os
 import tempfile
-import urllib
+import urllib.request
 import zipfile
+import json
+import eel
+import time
 from pathlib import Path
 from shutil import rmtree
 
 
-def download_and_extract_zip(download_url: str, local_folder_path: Path, clobber: bool = False):
+def download_and_extract_zip(download_url: str, local_folder_path: Path,
+                             clobber: bool = False, progress_callback: callable = None,
+                             unzip_callback: callable = None):
     """
     :param clobber: If true, we will delete anything found in local_folder_path.
     :return:
@@ -14,32 +19,139 @@ def download_and_extract_zip(download_url: str, local_folder_path: Path, clobber
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         downloadedZip = os.path.join(tmpdirname, 'downloaded.zip')
-        urllib.request.urlretrieve(download_url, downloadedZip)
+        urllib.request.urlretrieve(download_url, downloadedZip, progress_callback)
 
         if clobber and os.path.exists(local_folder_path):
             rmtree(local_folder_path)
+
+        if unzip_callback:
+            unzip_callback()
 
         with zipfile.ZipFile(downloadedZip, 'r') as zip_ref:
             zip_ref.extractall(local_folder_path)
 
 
-def download_gitlfs(repo_url: str, checkout_folder: Path, branch_name: str):
-    print('Starting download of a git repo... this might take a while.')
+def get_json_from_url(url):
+    response = urllib.request.urlopen(url)
+    return json.loads(response.read())
 
-    # Download the most of the files eg. https://github.com/RLBot/RLBotPack/archive/master.zip
-    download_and_extract_zip(
-        download_url=repo_url + '/archive/' + branch_name + '.zip',
-        local_folder_path=checkout_folder, clobber=True)
 
-    repo_extraction_name = '/' + repo_url.split('/')[-1] + '-' + branch_name + '/'
+def get_repo_size(repo_full_name):
+    """
+    Call GitHub API to get an estimate size of a GitHub repository.
+    :param repo_full_name: Full name of a repository. Example: 'RLBot/RLBotPack'
+    :return: Size of the repository in bytes, or 0 if the API call fails.
+    """
+    try:
+        data = get_json_from_url('https://api.github.com/repos/' + repo_full_name)
+        return int(data["size"]) * 1000
+    except:
+        return 0
 
-    file = open(checkout_folder + repo_extraction_name + '.gitattributes')
-    for line in file:
-        if line.split(' ')[1].endswith('=lfs'):
-            # Download gitlfs file
+
+
+class BotpackDownloader:
+    """
+    Downloads the botpack while updating the progress bar and status text.
+    """
+
+    PROGRESSBAR_UPDATE_INTERVAL = 0.1 # How often to update the progress bar (seconds)
+    ZIP_PORTION = 0.6 # How much of total progress should the zip file take
+
+    def __init__(self):
+        self.status = ''
+        self.current_progress = 0
+        self.total_progress = 0
+
+        self.estimated_zip_size = 0
+        self.current_file_bytes_downloaded = 0
+        self.lfs_file_count = 0
+        self.lfs_files_completed = 0
+        self.one_lfs_file_portion = 0
+        self.last_progressbar_update_time = 0
+
+
+    def update_progressbar_and_status(self):
+        # it's not necessary to update on every callback, so update
+        # only when some amount of time has passed
+        now = time.time()
+        if now > self.last_progressbar_update_time + self.PROGRESSBAR_UPDATE_INTERVAL:
+            self.last_progressbar_update_time = now
+
+            total_progress_percent = self.total_progress * 100
+            current_progress_percent = int(self.current_progress * 100)
+            status = f'{self.status} ({current_progress_percent}%)'
+
+            eel.updateDownloadProgress(total_progress_percent, status)
+
+
+    def zip_download_callback(self, block_count, block_size, _):
+        self.current_file_bytes_downloaded += block_size
+        self.current_progress = min(self.current_file_bytes_downloaded / self.estimated_zip_size, 1.0)
+        self.total_progress = self.current_progress * self.ZIP_PORTION
+        self.update_progressbar_and_status()
+
+
+    def unzip_callback(self):
+        eel.updateDownloadProgress(int(self.ZIP_PORTION * 100), 'Extracting ZIP file')
+
+
+    def lfs_download_callback(self, block_count, block_size, total_size):
+        self.current_file_bytes_downloaded += block_size
+        self.current_progress = self.current_file_bytes_downloaded / total_size
+        prev_files_progress = self.ZIP_PORTION + self.one_lfs_file_portion * self.lfs_files_completed
+        self.total_progress = prev_files_progress + self.current_progress * self.one_lfs_file_portion
+        self.update_progressbar_and_status()
+
+
+    def download(self, repo_owner: str, repo_name: str, branch_name: str, checkout_folder: Path):
+        repo_full_name = repo_owner + '/' + repo_name
+        repo_url = 'https://github.com/' + repo_full_name
+        repo_extraction_name = f'/{repo_name}-{branch_name}/'
+
+        self.status = f'Downloading {repo_full_name}-{branch_name}'
+        print(self.status)
+        self.progress = 0
+
+        # Unfortunately we can't know the size of the zip file before downloading it,
+        # so we have to get the size from the GitHub API.
+        self.estimated_zip_size = get_repo_size(repo_full_name) * 0.9
+
+        # If we fail to get the repo size, set it to a fallback value,
+        # so the progress bar will show atleast some progress.
+        # Let's assume the zip file is around 50 MB.
+        if self.estimated_zip_size == 0:
+            self.estimated_zip_size = 50_000_000
+
+        # Download the most of the files eg. https://github.com/RLBot/RLBotPack/archive/master.zip
+        download_and_extract_zip(
+            download_url=repo_url + '/archive/' + branch_name + '.zip',
+            local_folder_path=checkout_folder, clobber=True,
+            progress_callback=self.zip_download_callback,
+            unzip_callback=self.unzip_callback)
+
+        # Get paths of all LFS files we need to download from the .gitattributes file.
+        lfs_file_paths = []
+        gitattributes_file = open(checkout_folder + repo_extraction_name + '.gitattributes')
+        for line in gitattributes_file:
+            if line.split(' ')[1].endswith('=lfs'):
+                lfs_file_paths.append(line.split(' ')[0])
+        gitattributes_file.close()
+
+        self.lfs_file_count = len(lfs_file_paths)
+        # How much of total progress does one LFS file take:
+        self.one_lfs_file_portion = (1.0 - self.ZIP_PORTION) / self.lfs_file_count
+
+        # Download all LFS files.
+        for lfs_file_path in lfs_file_paths:
+            self.current_progress = 0
+            self.current_file_bytes_downloaded = 0
+            self.status = 'Downloading ' + lfs_file_path
+            print(self.status)
+
             urllib.request.urlretrieve(
-                repo_url + '/raw/' + branch_name + '/' + line.split(' ')[0],
-                checkout_folder + repo_extraction_name + line.split(' ')[0])
-    file.close()
+                repo_url + '/raw/' + branch_name + '/' + lfs_file_path,
+                checkout_folder + repo_extraction_name + lfs_file_path,
+                self.lfs_download_callback)
 
-    print('Done downloading git repo.')
+            self.lfs_files_completed += 1

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -49,14 +49,13 @@ def get_repo_size(repo_full_name):
         return 0
 
 
-
 class BotpackDownloader:
     """
     Downloads the botpack while updating the progress bar and status text.
     """
 
-    PROGRESSBAR_UPDATE_INTERVAL = 0.1 # How often to update the progress bar (seconds)
-    ZIP_PORTION = 0.6 # How much of total progress should the zip file take
+    PROGRESSBAR_UPDATE_INTERVAL = 0.1  # How often to update the progress bar (seconds)
+    ZIP_PORTION = 0.6  # How much of total progress should the zip file take
 
     def __init__(self):
         self.status = ''
@@ -69,7 +68,6 @@ class BotpackDownloader:
         self.lfs_files_completed = 0
         self.one_lfs_file_portion = 0
         self.last_progressbar_update_time = 0
-
 
     def update_progressbar_and_status(self):
         # it's not necessary to update on every callback, so update
@@ -84,17 +82,14 @@ class BotpackDownloader:
 
             eel.updateDownloadProgress(total_progress_percent, status)
 
-
     def zip_download_callback(self, block_count, block_size, _):
         self.current_file_bytes_downloaded += block_size
         self.current_progress = min(self.current_file_bytes_downloaded / self.estimated_zip_size, 1.0)
         self.total_progress = self.current_progress * self.ZIP_PORTION
         self.update_progressbar_and_status()
 
-
     def unzip_callback(self):
         eel.updateDownloadProgress(int(self.ZIP_PORTION * 100), 'Extracting ZIP file')
-
 
     def lfs_download_callback(self, block_count, block_size, total_size):
         self.current_file_bytes_downloaded += block_size
@@ -103,7 +98,6 @@ class BotpackDownloader:
         self.total_progress = prev_files_progress + self.current_progress * self.one_lfs_file_portion
         self.update_progressbar_and_status()
 
-
     def download(self, repo_owner: str, repo_name: str, branch_name: str, checkout_folder: Path):
         repo_full_name = repo_owner + '/' + repo_name
         repo_url = 'https://github.com/' + repo_full_name
@@ -111,7 +105,8 @@ class BotpackDownloader:
 
         self.status = f'Downloading {repo_full_name}-{branch_name}'
         print(self.status)
-        self.progress = 0
+        self.current_progress = 0
+        self.total_progress = 0
 
         # Unfortunately we can't know the size of the zip file before downloading it,
         # so we have to get the size from the GitHub API.

--- a/rlbot_gui/gui/js/main.js
+++ b/rlbot_gui/gui/js/main.js
@@ -65,7 +65,11 @@ const app = new Vue({
             folders: []
         },
         showFolderSettingsDialog: false,
-        showExtraOptions: false
+        showExtraOptions: false,
+        showDownloadProgressDialog: false,
+        downloadProgressPercent: 0,
+        downloadStatus: '',
+        showBotpackUpdateSnackbar: false
     },
     methods: {
         startMatch: function (event) {
@@ -120,7 +124,10 @@ const app = new Vue({
             eel.install_package(this.packageString)(onInstallationComplete);
         },
         downloadBotPack: function() {
-            this.showProgressSpinner = true;
+            this.showBotpackUpdateSnackbar = false;
+            this.showDownloadProgressDialog = true;
+            this.downloadStatus = "Starting"
+            this.downloadProgressPercent = 0;
             eel.download_bot_pack()(botPackDownloaded);
         },
         showBotInExplorer: function (botPath) {
@@ -164,9 +171,16 @@ eel.get_language_support()((support) => {
     applyLanguageWarnings();
 });
 
+eel.is_botpack_up_to_date()(botpackUpdateChecked);
+
+function botpackUpdateChecked(isBotpackUpToDate) {
+    app.showBotpackUpdateSnackbar = !isBotpackUpToDate;
+}
+
 function botPackDownloaded(response) {
     app.snackbarContent = 'Downloaded Bot Pack!';
     app.showSnackbar = true;
+    app.showDownloadProgressDialog = false;
     eel.get_folder_settings()(folderSettingsReceived);
     eel.scan_for_bots()(botsReceived);
 }
@@ -240,6 +254,12 @@ function onInstallationComplete(result) {
     app.snackbarContent = message;
     app.showSnackbar = true;
     app.showProgressSpinner = false;
+}
+
+eel.expose(updateDownloadProgress)
+function updateDownloadProgress(progress, status) {
+    app.downloadStatus = status;
+    app.downloadProgressPercent = progress;
 }
 
 Vue.component('mutator-field', {

--- a/rlbot_gui/gui/js/main.js
+++ b/rlbot_gui/gui/js/main.js
@@ -113,7 +113,7 @@ const app = new Vue({
             this.matchSettings.instant_start = false;
             this.matchSettings.enable_lockstep = false;
             this.resetMutatorsToDefault();
-        
+
             this.updateBGImage(this.matchSettings.map);
         },
         updateBGImage: function(mapName) {
@@ -256,7 +256,7 @@ function onInstallationComplete(result) {
     app.showProgressSpinner = false;
 }
 
-eel.expose(updateDownloadProgress)
+eel.expose(updateDownloadProgress);
 function updateDownloadProgress(progress, status) {
     app.downloadStatus = status;
     app.downloadProgressPercent = progress;

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -260,6 +260,11 @@
 				<span>{{snackbarContent}}</span>
 			</md-snackbar>
 
+			<md-snackbar md-position="center" :md-active="showBotpackUpdateSnackbar" md-persistent md-duration="10000">
+				<span>Bot Pack update available!</span>
+				<md-button class="md-accent" @click="downloadBotPack()">Download</md-button>
+			</md-snackbar>
+
 			<md-dialog v-if="activeBot && activeBot.info" :md-active.sync="showBotInfo">
 				<md-dialog-title>
 					{{activeBot.name}}
@@ -355,6 +360,22 @@
 					<md-button class="md-raised md-primary" @click="applyFolderSettings()">Apply</md-button>
 					<md-button @click="showFolderSettingsDialog = false">Close</md-button>
 				</md-dialog-actions>
+			</md-dialog>
+
+			<md-dialog :md-active.sync="showDownloadProgressDialog"
+					   :md-close-on-esc="false"
+					   :md-click-outside-to-close="false">
+				<md-dialog-title>Downloading Bot Pack</md-dialog-title>
+
+				<md-dialog-content>
+					<div class="md-layout md-gutter" :class="`md-alignment-center-center`">
+						<md-icon class="md-size-4x">cloud_download</md-icon>
+					</div>
+					<md-progress-bar class="md-accent" md-mode="determinate" :md-value="downloadProgressPercent">
+					</md-progress-bar>
+					<p>{{ downloadStatus }}</p>
+				</md-dialog-content>
+				
 			</md-dialog>
 
 		</div>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.29'
+__version__ = '0.0.30'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
This adds a progress bar while downloading the botpack:

![image](https://user-images.githubusercontent.com/18472149/65470693-8c1c2600-de6c-11e9-9d94-88af8731c80e.png)

The dialog is intentionally non-dismissable, because users shouldn't be starting matches during the download (bot files will get deleted).

I also added checking if there is a newer version of the botpack available, using the GitHub API.

All users will get the snackbar notification when they get this update for the first time, but I think that's alright, because 99% people don't have the latest botpack anyway.