### PR TITLE
Add a 'Filter' field for searching bots

### DIFF
--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -135,9 +135,20 @@ body {
   display: inline-flex;
 }
 
+.bot-pool .bot-filter {
+  margin-top: -10px;
+  margin-bottom: -20px;
+  min-width: 150px;
+  margin-left: 20px;
+}
+
 .bot-card img {
   height: 1.5rem;
   margin: 3px;
+}
+
+.filtered {
+  opacity: 0.2;
 }
 
 .bot-card img.darkened {

--- a/rlbot_gui/gui/js/main.js
+++ b/rlbot_gui/gui/js/main.js
@@ -69,7 +69,8 @@ const app = new Vue({
         showDownloadProgressDialog: false,
         downloadProgressPercent: 0,
         downloadStatus: '',
-        showBotpackUpdateSnackbar: false
+        showBotpackUpdateSnackbar: false,
+        botNameFilter: ''
     },
     methods: {
         startMatch: function (event) {
@@ -156,6 +157,9 @@ const app = new Vue({
             eel.save_folder_settings(app.folderSettings);
             app.botPool = STARTING_BOT_POOL;
             eel.scan_for_bots()(botsReceived);
+        },
+        passesFilter: function(botName) {
+            return botName.toLowerCase().includes(this.botNameFilter.toLowerCase());
         }
     }
 });

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -94,10 +94,18 @@
 						<md-icon>settings</md-icon>
 						<md-tooltip md-direction="top">Manage bot folders</md-tooltip>
 					</md-button>
+
+					<div class="bot-filter">
+						<md-field md-inline md-clearable>
+							<label>Filter</label>
+							<md-input v-model="botNameFilter"></md-input>
+						</md-field>
+					</div>
+
 				</md-card-header>
 
 				<draggable v-model="botPool" :options="{group: {name:'bots', pull:'clone', put:false}, sort: false}">
-					<md-card class="bot-card md-elevation-3" v-for="bot in botPool" >
+					<md-card class="bot-card md-elevation-3" v-for="bot in botPool" :class="{'filtered': !passesFilter(bot.name)}">
 						<button class="center-flex secret-button" @click="addToTeam(bot, teamSelection)">
 							<img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
 							<img v-if="bot.logo" v-bind:src="bot.logo">

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.30'
+__version__ = '0.0.31'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
This adds a clearable text field for searching bots by their name, case insensitive.

[![Image from Gyazo](https://i.gyazo.com/f7ff6c1f4af1a666444618f5cec2c30e.gif)](https://gyazo.com/f7ff6c1f4af1a666444618f5cec2c30e)

I also tried removing the bot cards entirely when filtered out, but it was clunky - the Player Types card was resizing too much and the bot logos took a while to load in again. So I think making them just less visible is better.