### PR TITLE
Avoid including bot logos from the bot pack in distributions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ RLBotPack/
 RLBotPackDeletable/
 MyBots/
 rlbot_gui/gui/imgs/logos
+
+# Hello! If you're adding something here, consider also adding it to MANIFEST.in!
+# See the README.md for details.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include rlbot_gui/gui *
+prune rlbot_gui/gui/imgs/logos*

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ https://github.com/RLBot/RLBot/wiki/Deploying-Changes#first-time-setup
 1. Look in setup.py and increment the version number.
 1. Run `publish-to-pypi-prod.bat`
 
+#### Note
+When deploying to pypi, the files which get included are controlled by the MANIFEST.in file.
+You may wish to exclude anything which does not belong in the initial install, e.g.
+bot logos which get copied in to the GUI folder as you use the program.
+
+As a rule of thumb, if you add something to .gitignore, it may also belong in MANIFEST.in
+as a prune line.
+
 ### Building the Installer
 
 You can build an installer executable for users to download. You will rarely need

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.31'
+__version__ = '0.0.32'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
The problem arises when this happens:
- Developer clones RLBotGUI and starts working on it
- Downloads the bot pack as part of testing
- RLBotGUI copies the bot logos into the gui directory in order to display them
- The logos get included when publishing RLBotGUI to pypi

The download gets filled up with bot logo clutter.

Seems like a good rule to follow is that if you add a new line to .gitignore (which I did) it's also good to consider MANIFEST.in.