### PR TITLE
Kill all pids when restarting a match

### DIFF
--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -98,7 +98,7 @@ def start_match_helper(bot_list, match_settings):
     global sm
     if sm is not None:
         try:
-            sm.shut_down()
+            sm.shut_down(kill_all_pids=True)
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
This addresses the issue where `BotHelperProcess`es would not be killed when *start match* is pressed. This lead to unwanted ghost inputs and meant that a person always had to press *stop* before *start match*.