### PR TITLE
Adding a rewind button to the sandbox.

### DIFF
--- a/rlbot_gui/type_translation/set_state_translation.py
+++ b/rlbot_gui/type_translation/set_state_translation.py
@@ -13,6 +13,8 @@ def dict_to_game_state(state_dict):
             car_state = CarState()
             if 'physics' in car:
                 car_state.physics = dict_to_physics(car['physics'])
+            if 'boost_amount' in car:
+                car_state.boost_amount = car['boost_amount']
             gs.cars[int(index)] = car_state
     if 'game_info' in state_dict:
         gs.game_info = GameInfoState()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.42'
+__version__ = '0.0.43'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
It's useful for debugging. If you're testing your bot and it does something dumb, you can click rewind and probably see it again. Combined with the freeze feature, this gives you an opportunity to set a breakpoint and really dig into it.

It's a bit janky because:
- It can't literally rewind the clock
- It can't set boost pad state
- If you try to rewind soon after the countdown, the ball may teleport into the goal
- If you try to rewind during a replay, weird stuff will happen

![image](https://user-images.githubusercontent.com/575644/75618112-22403080-5b1e-11ea-9e85-772076f3c66b.png)
