### PR TITLE
Remove Badlands from "standard maps"

### DIFF
--- a/rlbot_gui/gui/json/standard-maps.json
+++ b/rlbot_gui/gui/json/standard-maps.json
@@ -24,8 +24,6 @@
     "DFHStadium_Snowy",
     "Mannfield_Snowy",
     "UtopiaColiseum_Snowy",
-    "Badlands",
-    "Badlands_Night",
     "ForbiddenTemple",
     "RivalsArena",
     "Farmstead_Night",


### PR DESCRIPTION
"wait, wtf. Why is the wasteland in the random map rotation not the ranked version but the outdated one with weird dimensions?"
- @oxrock