### PR TITLE
Let showroom use selected map

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -245,10 +245,10 @@ def save_looks(looks: dict, path: str):
 
 
 @eel.expose
-def spawn_car_for_viewing(looks: dict, team: int, showcase_type: str):
+def spawn_car_for_viewing(looks: dict, team: int, showcase_type: str, map_name: str):
     looks_config = convert_to_looks_config(looks)
     loadout_config = load_bot_appearance(looks_config, team)
-    spawn_car_in_showroom(loadout_config, team, showcase_type)
+    spawn_car_in_showroom(loadout_config, team, showcase_type, map_name)
 
 
 @eel.expose

--- a/rlbot_gui/gui/appearance-editor.vue
+++ b/rlbot_gui/gui/appearance-editor.vue
@@ -96,7 +96,7 @@
 		components: {
 			'item-field': ItemField
 		},
-		props: ['active', 'path', 'activeBot'],
+		props: ['active', 'path', 'activeBot', 'map'],
 		data () {
 			return {
 				config: {
@@ -173,7 +173,7 @@
 				this.$emit('appearance-editor-closed');
 			},
 			spawnCarForViewing: function(team) {
-				eel.spawn_car_for_viewing(this.config, team, this.selectedShowcaseType);
+				eel.spawn_car_for_viewing(this.config, team, this.selectedShowcaseType, this.map);
 			},
 			blueColors: i => { return {
 				h: (i % 10) / 20.5 + .33,

--- a/rlbot_gui/gui/main.vue
+++ b/rlbot_gui/gui/main.vue
@@ -384,6 +384,7 @@
 				v-bind:active="appearanceEditorVisible"
 				v-bind:active-bot="activeBot"
 				v-bind:path="appearancePath"
+				v-bind:map="matchSettings.map"
 				v-on:appearance-editor-closed="appearanceEditorVisible = false"
 				id="appearance-editor-dialog" />
 

--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -27,10 +27,10 @@ def create_player_config(bot, human_index_tracker: IncrementingInteger):
     return player_config
 
 
-def spawn_car_in_showroom(loadout_config: LoadoutConfig, team: int, showcase_type: str):
+def spawn_car_in_showroom(loadout_config: LoadoutConfig, team: int, showcase_type: str, map_name: str):
     match_config = MatchConfig()
     match_config.game_mode = 'Soccer'
-    match_config.game_map = 'Mannfield'
+    match_config.game_map = map_name
     match_config.instant_start = True
     match_config.existing_match_behavior = 'Continue And Spawn'
     match_config.networking_role = NetworkingRole.none

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.47'
+__version__ = '0.0.48'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Let showroom match starter use the selected map on the main screen, instead of just Mannfield. Feature requested by HoveringBanana