### PR TITLE
Upgrade script to upgrade the upgrade script.

### DIFF
--- a/pynsist_helpers/upgrade.py
+++ b/pynsist_helpers/upgrade.py
@@ -27,7 +27,7 @@ def upgrade():
         elif public_utils.is_safe_to_upgrade():
             # Upgrade only the rlbot-related stuff.
             rlbot_requirements = os.path.join(folder, 'rlbot-requirements.txt')
-            pipmain(['install', '-r', rlbot_requirements, '--upgrade', '--upgrade-strategy=eager'])
+            pipmain(['install', '-r', rlbot_requirements, '--upgrade'])
 
     except (ImportError, ModuleNotFoundError):
         # First time installation, install lots of stuff

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -22,6 +22,7 @@ from rlbot_gui.bot_management.downloader import BotpackDownloader, get_json_from
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, \
     do_infinite_loop_content, spawn_car_in_showroom, set_game_state, fetch_game_tick_packet
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
+from rlbot_gui.upgrade.upgrade_replacer import replace_upgrade_file
 
 DEFAULT_BOT_FOLDER = 'default_bot_folder'
 BOTPACK_FOLDER = 'RLBotPackDeletable'
@@ -494,6 +495,7 @@ def init_settings():
 
 def start():
     init_settings()
+    replace_upgrade_file()
     gui_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'gui')
     eel.init(gui_folder)
 

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -22,7 +22,6 @@ from rlbot_gui.bot_management.downloader import BotpackDownloader, get_json_from
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, \
     do_infinite_loop_content, spawn_car_in_showroom, set_game_state, fetch_game_tick_packet
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
-from rlbot_gui.upgrade.upgrade_replacer import replace_upgrade_file
 
 DEFAULT_BOT_FOLDER = 'default_bot_folder'
 BOTPACK_FOLDER = 'RLBotPackDeletable'
@@ -495,7 +494,6 @@ def init_settings():
 
 def start():
     init_settings()
-    replace_upgrade_file()
     gui_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'gui')
     eel.init(gui_folder)
 

--- a/rlbot_gui/upgrade/upgrade_replacer.py
+++ b/rlbot_gui/upgrade/upgrade_replacer.py
@@ -1,0 +1,21 @@
+import shutil
+from pathlib import Path
+
+from env.Lib import os
+
+
+def replace_upgrade_file():
+    """
+    RLBotGUI installations on windows generally have a file at ./pynsist_helpers/upgrade.py which is
+    NOT part of the rlbot_gui python package. It lives outside the package for the sake of upgrading
+    the package. However, sometimes we wish to push updates to upgrade.py without requiring users to
+    manually reinstall. This function takes a version of the upgrade script vended inside rlbot_gui
+    and copies it to the external location.
+    """
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    fresh_upgrade_file = Path(os.path.join(dir_path, 'upgrade_script.py'))
+    existing_upgrade_file = Path('./pynsist_helpers/upgrade.py')
+
+    if existing_upgrade_file.exists():
+        shutil.copyfile(fresh_upgrade_file, existing_upgrade_file)
+        print(f"Successfully replaced {existing_upgrade_file.absolute()}.")

--- a/rlbot_gui/upgrade/upgrade_script.py
+++ b/rlbot_gui/upgrade/upgrade_script.py
@@ -1,0 +1,39 @@
+# https://stackoverflow.com/a/51704613
+try:
+    from pip import main as pipmain
+except ImportError:
+    from pip._internal import main as pipmain
+
+DEFAULT_LOGGER = 'rlbot'
+
+
+def upgrade():
+    package = 'rlbot'
+
+    import importlib
+    import os
+    folder = os.path.dirname(os.path.realpath(__file__))
+
+    try:
+        # https://stackoverflow.com/a/24773951
+        importlib.import_module(package)
+
+        from rlbot.utils import public_utils, logging_utils
+
+        logger = logging_utils.get_logger(DEFAULT_LOGGER)
+        if not public_utils.have_internet():
+            logger.log(logging_utils.logging_level,
+                       'Skipping upgrade check for now since it looks like you have no internet')
+        elif public_utils.is_safe_to_upgrade():
+            # Upgrade only the rlbot-related stuff.
+            rlbot_requirements = os.path.join(folder, 'rlbot-requirements.txt')
+            pipmain(['install', '-r', rlbot_requirements, '--upgrade'])
+
+    except (ImportError, ModuleNotFoundError):
+        # First time installation, install lots of stuff
+        all_requirements = os.path.join(folder, 'requirements.txt')
+        pipmain(['install', '-r', all_requirements])
+
+
+if __name__ == '__main__':
+    upgrade()

--- a/run.py
+++ b/run.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from rlbot_gui import gui
+from rlbot_gui.upgrade.upgrade_replacer import replace_upgrade_file
 
 # Insert the pkgs directory into the python path. This is necessary when
 # running the pynsist installed version.
@@ -10,4 +11,5 @@ pkgdir = os.path.join(scriptdir, 'pkgs')
 sys.path.insert(0, pkgdir)
 
 if __name__ == '__main__':
+    replace_upgrade_file()
     gui.start()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.52'
+__version__ = '0.0.53'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
RLBotGUI installations on windows generally have a file at ./pynsist_helpers/upgrade.py which is NOT part of the rlbot_gui python package. It lives outside the package for the sake of upgrading the package. Unfortunately that means we can't deploy changes to it. Normally users would need to completely reinstall RLBotGUI to get a new version of that file.

This is a hacky way of getting around that. My motivation for doing it right now is I want to use `pipmain(['install', '-r', rlbot_requirements, '--upgrade'])` instead of `pipmain(['install', '-r', rlbot_requirements, '--upgrade', '--upgrade-strategy=eager'])` so we don't obnoxiously upgrade PyQt5 all the time.

Based on my testing, --upgrade still does the vital job of upgrading rlbot and rlbot_gui as expected. If I'm wrong about that, then this change could break auto upgrades for everybody which would be a big disaster. Documentation for --upgrade: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-u