### PR TITLE
Toggles for enable_rendering, enable_state_setting, auto_save_replay.

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -135,6 +135,9 @@ def validate_bots(bots):
 def get_match_settings():
     settings = load_settings()
     match_settings = settings.value(MATCH_SETTINGS_KEY, type=dict)
+    if 'enable_state_setting' not in match_settings:
+        # Set this to true by default for backwards compatiblity with state setting sandbox, snek, and sniper
+        match_settings['enable_state_setting'] = True
     return match_settings if match_settings else None
 
 

--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -53,7 +53,7 @@ body {
 }
 
 .team-entries {
-  min-height: 220px;
+  min-height: 180px;
   padding: 5px;
 }
 

--- a/rlbot_gui/gui/main.vue
+++ b/rlbot_gui/gui/main.vue
@@ -8,6 +8,9 @@
 			<h3 class="md-title" style="flex: 1">RLBot</h3>
 
 			<div class="md-toolbar-section-end">
+				<span v-if="!matchSettings.enable_state_setting">
+					<md-icon class="warning-icon">warning</md-icon><md-tooltip md-direction="bottom">State setting is turned off, sandbox won't work!</md-tooltip>
+				</span>
 				<md-button @click="$router.replace('/sandbox')">
 					State Setting Sandbox
 				</md-button>
@@ -211,9 +214,18 @@
 					<md-dialog-title>Extra Options</md-dialog-title>
 
 					<md-dialog-content>
-						<md-switch v-model="matchSettings.skip_replays">Skip Replays</md-switch>
-						<md-switch v-model="matchSettings.instant_start">Instant Start</md-switch>
-						<md-switch v-model="matchSettings.enable_lockstep">Enable lockstep</md-switch>
+						<div class="md-layout">
+							<div class="md-layout-item">
+								<div><md-switch v-model="matchSettings.skip_replays">Skip Replays</md-switch></div>
+								<div><md-switch v-model="matchSettings.instant_start">Instant Start</md-switch></div>
+								<div><md-switch v-model="matchSettings.enable_lockstep">Enable Lockstep</md-switch></div>
+							</div>
+							<div class="md-layout-item">
+								<div><md-switch v-model="matchSettings.enable_rendering">Enable Rendering (bots can draw on screen)</md-switch></div>
+								<div><md-switch v-model="matchSettings.enable_state_setting">Enable State Setting (bots can teleport)</md-switch></div>
+								<div><md-switch v-model="matchSettings.auto_save_replay">Auto Save Replay</md-switch></div>
+							</div>
+						</div>
 						<mutator-field label="Existing Match Behaviour" :options="matchOptions.match_behaviours" v-model="matchSettings.match_behavior"></mutator-field>
 					</md-dialog-content>
 
@@ -464,6 +476,9 @@
 						respawn_time: null
 					},
 					randomizeMap: false,
+					enable_rendering: false,
+					enable_state_setting: false,
+					auto_save_replay: false,
 				},
 				randomMapPool: [],
 				showMutatorDialog: false,
@@ -553,6 +568,9 @@
 				this.matchSettings.instant_start = false;
 				this.matchSettings.enable_lockstep = false;
 				this.matchSettings.randomizeMap = false;
+				this.matchSettings.enable_rendering = false;
+				this.matchSettings.enable_state_setting = true;
+				this.matchSettings.auto_save_replay = false;
 				this.resetMutatorsToDefault();
 
 				this.updateBGImage(this.matchSettings.map);
@@ -654,7 +672,7 @@
 
 			matchSettingsReceived: function (matchSettings) {
 				if (matchSettings) {
-					this.matchSettings = matchSettings;
+					Object.assign(this.matchSettings, matchSettings);
 					this.updateBGImage(this.matchSettings.map);
 				} else {
 					this.resetMatchSettingsToDefault();

--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -75,7 +75,7 @@ def spawn_car_in_showroom(loadout_config: LoadoutConfig, team: int, showcase_typ
         game_state.cars[0].physics.location.y = -1140
         game_state.cars[0].physics.velocity.x = 2300
         game_state.cars[0].physics.angular_velocity.z = 3.5
-        
+
     elif showcase_type == "throttle":
         player_input.throttle = 1
         player_input.steer = 0.56
@@ -124,6 +124,9 @@ def start_match_helper(bot_list, match_settings):
     match_config.skip_replays = match_settings['skip_replays']
     match_config.instant_start = match_settings['instant_start']
     match_config.enable_lockstep = match_settings['enable_lockstep']
+    match_config.enable_rendering = match_settings['enable_rendering']
+    match_config.enable_state_setting = match_settings['enable_state_setting']
+    match_config.auto_save_replay = match_settings['auto_save_replay']
     match_config.existing_match_behavior = match_settings['match_behavior']
     match_config.mutators = MutatorConfig()
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.56'
+__version__ = '0.0.57'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/575644/82166059-2140b480-986c-11ea-8cac-4341a2978bcf.png)

Enable State Setting will be on by default so that Snek, Sniper, and the State Setting Sandbox continue to work.

The others will be off by default.