### PR TITLE
Calling out rendering and state setting config on match start.

### DIFF
--- a/rlbot_gui/gui/main.vue
+++ b/rlbot_gui/gui/main.vue
@@ -280,7 +280,7 @@
 			</md-card-content>
 		</md-card>
 
-		<md-snackbar md-position="center" :md-active.sync="showSnackbar" md-persistent>
+		<md-snackbar md-position="center" :md-active.sync="showSnackbar" :md-duration="5000" md-persistent>
 			<span>{{snackbarContent}}</span>
 		</md-snackbar>
 
@@ -529,6 +529,11 @@
 
 				const blueBots = this.blueTeam.map((bot) => { return  {'name': bot.name, 'team': 0, 'type': bot.type, 'skill': bot.skill, 'path': bot.path} });
 				const orangeBots = this.orangeTeam.map((bot) => { return  {'name': bot.name, 'team': 1, 'type': bot.type, 'skill': bot.skill, 'path': bot.path} });
+
+				const renderingMsg = this.matchSettings.enable_rendering ? "🎨 Rendering is ON." : "🚫 Rendering is OFF.";
+				const stateSettingMsg = this.matchSettings.enable_state_setting ? "✨ State Setting is ON." : "🚫 State Setting is OFF.";
+				this.snackbarContent = renderingMsg + " " + stateSettingMsg + " See EXTRA to change.";
+				this.showSnackbar = true;
 
 				// start match asynchronously, so it doesn't block things like updating the background image
 				setTimeout(() => {

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.59'
+__version__ = '0.0.60'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Message pops up after user clicks on Start Match. Makes people aware that these settings exist, to reduce confusion. Also a useful reminder for people who know about the settings but may have forgotten to change them.

![image](https://user-images.githubusercontent.com/575644/83334495-c17ade00-a25b-11ea-937a-3bb2ec4ee523.png)
