### PR TITLE
Adding a nav bar to story mode with back btn. Tweaking styling.

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -589,7 +589,7 @@ def launch_eel(use_chrome):
     # installed to pip locally using this technique https://stackoverflow.com/a/49684835
     # The suppress_error=True avoids the error "'options' argument deprecated in v1.0.0", we need to keep the
     # options argument since a lot of our user base has an older version of eel.
-    eel.start('main.html', size=(1300, 845), block=False, callback=on_websocket_close, options=options,
+    eel.start('main.html', size=(1300, 870), block=False, callback=on_websocket_close, options=options,
               disable_cache=True, mode=browser_mode, port=port, suppress_error=True)
 
 

--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -26,7 +26,7 @@ body, html {
   min-height: 100%;
 }
 
-.rlbot-main-config .card-body {
+.rlbot-main-config .card-body, .settings-card .card-body {
   padding: 5px;
 }
 

--- a/rlbot_gui/gui/js/story-challenges.js
+++ b/rlbot_gui/gui/js/story-challenges.js
@@ -168,7 +168,7 @@ export default {
                         {{getCityStateTooltip(cityId)}}
                     </b-tooltip>
                     <b-card 
-                        class="mt-2"
+                        class="mt-2 ml-0 mr-0 settings-card"
                         :title="'City: ' + cityDisplayInfo[selectedCityId].displayName"
                         bg-variant="dark"
                         text-variant="light"
@@ -176,7 +176,8 @@ export default {
                         <div>
                             <b-img
                                 :src="'imgs/arenas/' + challenges[selectedCityId][0].map  +'.jpg'"
-                                height="100px"/>
+                                height="100px"
+                                class="mr-2" />
                             <p class="story-inline" style="max-width:400px; display:inline-block">
                             {{cityDisplayInfo[selectedCityId].message}}
                             </p>

--- a/rlbot_gui/gui/js/story-mode.js
+++ b/rlbot_gui/gui/js/story-mode.js
@@ -15,6 +15,26 @@ const DEBUG_STORY_STATE = false;
 export default {
     name: 'story',
     template: `
+    <div>
+    <b-navbar class="navbar">
+        <b-navbar-brand>
+            <img class="logo" src="imgs/rlbot_logo.png">
+            <span class="rlbot-brand" style="flex: 1">Story Mode</span>
+        </b-navbar-brand>
+        <b-navbar-nav class="ml-auto">
+            <alter-save-state v-model="saveState" v-if="debugStoryState"/>
+            <b-dropdown class="ml-4" right variant="dark">
+				<template v-slot:button-content>
+					Menu
+				</template>
+                <b-dropdown-item @click="deleteSave" v-if="ui_state > ${UI_STATES.START_SCREEN}">Delete Save</b-dropdown-item>
+			</b-dropdown>
+			<b-button class="ml-4" @click="watching = false; $router.replace('/')" variant="dark">
+                Back
+            </b-button>
+        </b-navbar-nav>
+    </b-navbar>
+
     <b-container fluid>
         <story-start v-on:started="startStory" v-if="ui_state === ${UI_STATES.START_SCREEN}">
         </story-start>
@@ -26,11 +46,8 @@ export default {
             v-bind:saveState="saveState"
             v-if="ui_state == ${UI_STATES.STORY_CHALLENGES}">
         </story-challenges>
-
-        <b-button @click="deleteSave" variant="danger" v-if="ui_state > ${UI_STATES.START_SCREEN}">Delete Save</b-button>
-
-        <alter-save-state v-model="saveState" v-if="debugStoryState"/>
     </b-container>
+    </div>
     `,
     components: {
         'story-start': StoryStart,

--- a/rlbot_gui/gui/main.html
+++ b/rlbot_gui/gui/main.html
@@ -24,7 +24,7 @@
 	<div id="app" :style="bodyStyle">
 
 <!--		https://stackoverflow.com/a/55296309/280852-->
-		<keep-alive include="match-setup,sandbox">
+		<keep-alive include="match-setup,sandbox,story">
 			<router-view @background-change="changeBackgroundImage"></router-view>
 		</keep-alive>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/575644/85593726-25df5200-b5fc-11ea-9c96-af8bde4b7d76.png)

Somebody requested a back button, and this felt like the cleanest / most consistent way to do it.

I also fixed the padding on the state setting sandbox so that the ball / cars are aligned correctly with the field image.