### PR TITLE
Story Mode: Add color matching on teams

### DIFF
--- a/rlbot_gui/story/load_story_descriptions.py
+++ b/rlbot_gui/story/load_story_descriptions.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from os import path
+from copy import deepcopy
 
 import json
 
@@ -31,10 +32,12 @@ def get_cities(story_id):
 
 
 def get_challenges_by_id(story_id):
-    challenges = get_cities(story_id)
-    challenges_by_id = {
-        challenge["id"]: challenge for city in challenges.values() for challenge in city["challenges"]
-    }
+    cities = get_cities(story_id)
+    challenges_by_id = { }
+    for city_id, city in cities.items():
+        for challenge in  city["challenges"]:
+            challenges_by_id[challenge["id"]] = deepcopy(challenge)
+            challenges_by_id[challenge["id"]]["city_description"] = city["description"]
     return challenges_by_id
 
 

--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -21,7 +21,8 @@
         "TRYHARD": {
             "description": {
                 "message": "Place to start making your name! But know that everyone else is trying to do the same!",
-                "prereqs": ["INTRO"]
+                "prereqs": ["INTRO"],
+                "color": 16
             },
             "challenges": [
                 {
@@ -47,7 +48,8 @@
         "PBOOST": {
             "description": {
                 "message": "This city is usually going through a storm. Legend says, Boost is how they have managed to prosper despite those conditions.",
-                "prereqs": ["INTRO"]
+                "prereqs": ["INTRO"],
+                "color": 32
             },
             "challenges": [
                 {
@@ -69,7 +71,8 @@
         "WASTELAND": {
             "description": {
                 "message": "Don't expect politeness here. Home of the demo experts!",
-                "prereqs": ["TRYHARD", "PBOOST"]
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 36
             },
             "challenges": [
                 {
@@ -99,7 +102,8 @@
         "CAMPANDSNIPE": {
             "description": {
                 "message": "This city has a different feel. Sometimes the ball is possesed, other times its the cars. Be careful, you may be next!",
-                "prereqs": ["TRYHARD", "PBOOST"]
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 39
             },
             "challenges": [
             {
@@ -134,7 +138,8 @@
         "CHAMPIONSIAN": {
             "description": {
                 "message": "You have made it far but this is the next level. The odds are stacked against you but if you win here, you will be the Champion of this world.",
-                "prereqs": ["WASTELAND", "CAMPANDSNIPE"]
+                "prereqs": ["WASTELAND", "CAMPANDSNIPE"],
+                "color": 69
             },
             "challenges": [
                 {

--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -8,6 +8,9 @@ import time
 import traceback
 
 import eel
+from rlbot.matchconfig.loadout_config import LoadoutConfig
+from rlbot.parsing.bot_config_bundle import get_bot_config_bundle
+from rlbot.parsing.agent_config_parser import load_bot_appearance
 from rlbot.utils.game_state_util import GameState, CarState
 from rlbot.utils.structures.game_data_struct import GameTickPacket, Vector3
 from rlbot.parsing.match_settings_config_parser import (
@@ -102,6 +105,9 @@ def rlbot_to_player_config(player: dict, team: Team):
     player_config.name = player["name"]
     player_config.team = team.value
     player_config.config_path = bot_path
+    config = get_bot_config_bundle(bot_path)
+    loadout = load_bot_appearance(config.get_looks_config(), team.value)
+    player_config.loadout_config = loadout
     return player_config
 
 
@@ -146,10 +152,14 @@ def make_player_configs(
         print(i)
         teammate = all_bots[human_picks[i]]
         config = bot_to_player(teammate, Team.BLUE)
+        config.loadout_config.custom_color_id = team_info["color_secondary"]
         player_configs.append(config)
 
     for opponent in challenge["opponentBots"]:
         bot = bot_to_player(all_bots[opponent], Team.ORANGE)
+        color = challenge.get("city_description", {}).get("color")
+        if color:
+            bot.loadout_config.team_color_id = color
         player_configs.append(bot)
 
     return player_configs


### PR DESCRIPTION
All opponents in the same city have the same primary colors.
All user's teammates use the team color as the secondary color.

Here are the city colors:

- Tryhard: 16, Brown
- Boost: 32, Orange
- Wasteland: 36, Red
- Campandsnipe: 39, Pink
- Championsian: 69, Purplish Red