### PR TITLE
Story: Update easy config to have a 3v3 against cryo

### DIFF
--- a/rlbot_gui/story/story-easy.json
+++ b/rlbot_gui/story/story-easy.json
@@ -51,18 +51,18 @@
             },
             "challenges": [
                 {
-                    "id": "PBOOST-1",
-                    "humanTeamSize": 2,
-                    "opponentBots": ["cryo", "cryo", "cryo"],
-                    "map": "UtopiaColiseum_Snowy",
-                    "display": "Bundle up to survive the deep freeze"
-                },
-                {
                     "id": "PBOOST-2",
                     "humanTeamSize": 2,
                     "opponentBots": ["rashbot", "stick", "leaf"],
                     "map": "Mannfield_Stormy",
                     "display": "2v3! Get through this storm of Marvin bots!"
+                },
+                {
+                    "id": "PBOOST-1",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["cryo", "cryo", "cryo"],
+                    "map": "UtopiaColiseum_Snowy",
+                    "display": "Bundle up to survive the deep freeze"
                 }
             ]
         },


### PR DESCRIPTION
2v3 against cryo is a bit hard for Gold/plats which
is what the easy config targets. We turn it
into a 3v3.

We also switch the order so the user has more time
to earn currency before they must recruit the third
teammate.