### PR TITLE
Story: Add Kamael to Heatseeker 

### DIFF
--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -117,7 +117,7 @@
             {
                 "id": "CS-2",
                 "humanTeamSize": 1,
-                "opponentBots": ["leaf", "baf"],
+                "opponentBots": ["kamael", "baf"],
                 "limitations": ["half-field"],
                 "completionConditions": {
                     "goalsScored": 1

--- a/rlbot_gui/story/story-easy.json
+++ b/rlbot_gui/story/story-easy.json
@@ -21,7 +21,8 @@
         "TRYHARD": {
             "description": {
                 "message": "Place to start making your name! But know that everyone else is trying to do the same!",
-                "prereqs": ["INTRO"]
+                "prereqs": ["INTRO"],
+                "color": 16
             },
             "challenges": [
                 {
@@ -47,7 +48,8 @@
         "PBOOST": {
             "description": {
                 "message": "This city is usually going through a storm. Legend says, Boost is how they have managed to prosper despite those conditions.",
-                "prereqs": ["INTRO"]
+                "prereqs": ["INTRO"],
+                "color": 32
             },
             "challenges": [
                 {
@@ -69,7 +71,8 @@
         "WASTELAND": {
             "description": {
                 "message": "Don't expect politeness here. Home of the demo experts!",
-                "prereqs": ["TRYHARD", "PBOOST"]
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 36
             },
             "challenges": [
                 {
@@ -99,7 +102,8 @@
         "CAMPANDSNIPE": {
             "description": {
                 "message": "This city has a different feel. Sometimes the ball is possesed, other times its the cars. Be careful, you may be next!",
-                "prereqs": ["TRYHARD", "PBOOST"]
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 39
             },
             "challenges": [
             {
@@ -123,7 +127,8 @@
         "CHAMPIONSIAN": {
             "description": {
                 "message": "You have made it far but this is the next level. The odds are stacked against you but if you win here, you will be the Champion of this world.",
-                "prereqs": ["WASTELAND", "CAMPANDSNIPE"]
+                "prereqs": ["WASTELAND", "CAMPANDSNIPE"],
+                "color": 69
             },
             "challenges": [
                 {

--- a/rlbot_gui/story/story-easy.json
+++ b/rlbot_gui/story/story-easy.json
@@ -105,7 +105,7 @@
             {
                 "id": "CS-1",
                 "humanTeamSize": 2,
-                "opponentBots": ["leaf", "baf"],
+                "opponentBots": ["kamael", "baf"],
                 "limitations": ["half-field"],
                 "map": "AquaDome",
                 "display": "The ball is moving a lot faster! Win this heatseeker match!"


### PR DESCRIPTION
For default, we add Kamael in the 1v2. Default still uses adversitybot for the 2v2.
For easy, we add Kamael in the 2v2.

Minor unrelated change: Adding city colors to the easy config as well.