### PR TITLE
Adjust Story Economy

### DIFF
--- a/rlbot_gui/gui/js/story-challenges.js
+++ b/rlbot_gui/gui/js/story-challenges.js
@@ -93,7 +93,7 @@ export default {
                 <b-img src="imgs/story/coin.png" />
                 <p>
                 Congrats on finishing the challenge! 
-                You have earned 1 currency!
+                You have earned 2 currency!
                 </p>
                 <p>
                 You can use it to recruit previous opponents, 
@@ -210,7 +210,7 @@ export default {
                     <b-row class="mt-1 overflow-auto" style="max-height: 300px; min-height:300px">
                     <b-card no-body class="w-100">
                         <b-tabs content-class="mt-3" fill class="story-card-text">
-                            <b-tab title="Upgrades" >
+                            <b-tab title="Upgrades">
                                 <story-upgrades 
                                     v-bind:upgradeSaveState="saveState.upgrades"
                                     @purchase_upgrade="$emit('purchase_upgrade', $event)">

--- a/rlbot_gui/gui/js/story-mode.js
+++ b/rlbot_gui/gui/js/story-mode.js
@@ -97,10 +97,10 @@ export default {
             console.log("Starting match", id);
             eel.launch_challenge(id, pickedTeammates);
         },
-        purchaseUpgrade: function ({ id, currentCurrency }) {
+        purchaseUpgrade: function ({ id, currentCurrency, cost }) {
             // Send eel a message to add id to purchases and reduce currency
             console.log("Will purchase: ", id);
-            eel.purchase_upgrade(id, currentCurrency);
+            eel.purchase_upgrade(id, currentCurrency, cost);
         },
         recruit: function ({ id, currentCurrency }) {
             console.log("Will recruit ", id);

--- a/rlbot_gui/gui/js/story-upgrades.js
+++ b/rlbot_gui/gui/js/story-upgrades.js
@@ -3,18 +3,22 @@ const UPGRADES = [
     {
         "id": "boost-33",
         "text": "Boost Capacity: 33%",
+        "cost": 3,
     },
     {
         "id": "boost-100",
         "text": "Boost Capacity: 100%",
+        "cost": 3,
     },
     {
         "id": "boost-recharge",
         "text": "Auto-Recharge Boost",
+        "cost": 4,
     },
     {
         "id": "rumble",
         "text": "Rumble Powerups",
+        "cost": 6
     }
 ];
 
@@ -32,8 +36,9 @@ export default {
                 v-bind:id="upgrade.id"
                 variant="success"
                 v-bind:disabled="!upgrade.available"
-                @click="purchase(upgrade.id)">
-                Purchase
+                @click="purchase(upgrade)">
+                {{upgrade.cost}}
+                <b-img src="imgs/story/coin.png" height="30px"/>
             </b-button>
         </b-list-group-item>
     </b-list-group>
@@ -44,8 +49,9 @@ export default {
             let result = UPGRADES.map((item) => ({
                 id: item.id,
                 text: item.text,
+                cost: item.cost,
                 purchased: Boolean(this.upgradeSaveState[item.id]),
-                available: currency > 0
+                available: currency >= item.cost
             }));
 
             // Screw it, hard coding it is
@@ -59,11 +65,12 @@ export default {
         },
     },
     methods: {
-        purchase: function (id) {
-            console.log("In purchases", id);
+        purchase: function (item) {
+            console.log("In purchases", item.id);
             this.$emit('purchase_upgrade', {
-                id,
-                currentCurrency: this.upgradeSaveState.currency
+                id: item.id,
+                currentCurrency: this.upgradeSaveState.currency,
+                cost: item.cost
             });
         }
     }

--- a/rlbot_gui/story/story_runner.py
+++ b/rlbot_gui/story/story_runner.py
@@ -87,8 +87,8 @@ def launch_challenge(challenge_id, pickedTeammates):
 
 
 @eel.expose
-def purchase_upgrade(id, current_currency):
-    CURRENT_STATE.add_purchase(id, current_currency)
+def purchase_upgrade(id, current_currency, cost):
+    CURRENT_STATE.add_purchase(id, current_currency, cost)
     flush_save_state()
 
 
@@ -122,14 +122,14 @@ class StoryState:
 
         self.upgrades = {"currency": 0}
 
-    def add_purchase(self, id, current_currency):
+    def add_purchase(self, id, current_currency, cost):
         """The only validation we do is to make sure current_currency is correct.
         This is NOT a security mechanism, this is a bug prevention mechanism to
         avoid accidental double clicks.
         """
         if self.upgrades["currency"] == current_currency:
             self.upgrades[id] = True
-            self.upgrades["currency"] -= 1
+            self.upgrades["currency"] -= cost
 
     def add_recruit(self, id, current_currency):
         """The only validation we do is to make sure current_currency is correct.
@@ -158,7 +158,7 @@ class StoryState:
         if challenge_completed:
             index = len(self.challenges_attempts[challenge_id]) - 1
             self.challenges_completed[challenge_id] = index
-            self.upgrades["currency"] += 1
+            self.upgrades["currency"] += 2
 
     @staticmethod
     def new(name, color_secondary, story_id, custom_config):


### PR DESCRIPTION
A common problem is that users were buying upgrades before
recruiting teammates after the first match. This resulted
in them being "stuck" where they have to grind before moving
forward.

Another common feedback was that some upgrades were too powerful
and should be more expensive.

This commit adjusts the prices for upgrades and handles both. 
Thanks to @NicEastvillage for additional feedback/ideas on this.

Each match now gives you 2 currency (instead of 1). Recruiting
still costs 1 currency but upgrades have the following costs:

- Boost-33: 3
- Boost-100: 3
- Recharging boost: 4
- Rumble powerups: 6

This means that even after recruiting 1 person, boost-33 can be bought
after the second match. After recruiting 1 more teammate, boost-100 can
be bought after the 4th match.

This is how the costs look in the UI.
![image](https://user-images.githubusercontent.com/2160795/92066658-6f70b980-ed70-11ea-8d38-7ae7cde36e27.png)
