### PR TITLE
Custom Install Path via Registry

### DIFF
--- a/alternative-install/RLBotGUI.bat
+++ b/alternative-install/RLBotGUI.bat
@@ -2,18 +2,35 @@
 
 echo Installing RLBotGUI if necessary, then launching!
 
-if not exist "%LocalAppData%\RLBotGUIX" mkdir "%LocalAppData%\RLBotGUIX"
-pushd "%LocalAppData%\RLBotGUIX"
+rem Find if the key exists, and put the output into a temporary file so it isn't printed to the console
+reg query "HKEY_CURRENT_USER\SOFTWARE\rlbotgui\preferences" /v "AppDataPath" > tmp_out_file
+if %ERRORLEVEL% GTR 0 (
+  rem If the key isn't in the registry, then add the default path to the registry - the key is 'AppDataPath'
+  echo Adding the installation path to the registry...
+  reg add "HKEY_CURRENT_USER\SOFTWARE\rlbotgui\preferences" /v AppDataPath /t REG_SZ /d "%LocalAppData%"
 
-if not exist "%LocalAppData%\RLBotGUIX\Python37" (
+  rem Set the AppDataPath manually because, in this case, it's a constant
+  set AppDataPath="%LocalAppData%"
+) else (
+  rem Get AppDataPath's value from the registry and put it in a variable called 'AppDataPath'
+  FOR /f "tokens=3 skip=2" %%a IN ('reg query "HKEY_CURRENT_USER\SOFTWARE\rlbotgui\preferences" /v "AppDataPath"') DO set "AppDataPath=%%a"
+)
+
+rem Delete the temporary file
+del tmp_out_file
+
+if not exist "%AppDataPath%\RLBotGUIX" mkdir "%AppDataPath%\RLBotGUIX"
+pushd "%AppDataPath%\RLBotGUIX"
+
+if not exist "%AppDataPath%\RLBotGUIX\Python37" (
   echo Looks like we're missing RLBot's Python ^(3.7.9^), installing...
 
-  powershell Expand-Archive "%~dp0\python-3.7.9-custom-amd64.zip" "%LocalAppData%\RLBotGUIX\Python37"
+  powershell Expand-Archive "%~dp0\python-3.7.9-custom-amd64.zip" "%AppDataPath%\RLBotGUIX\Python37"
 
-  if exist "%LocalAppData%\RLBotGUIX\venv\pyvenv.cfg" (
+  if exist "%AppDataPath%\RLBotGUIX\venv\pyvenv.cfg" (
     echo Old venv detected, updating Python location so we don't have to reinstall...
     rem This is a custom python script that updates the Python location in the venv
-    "%LocalAppData%\RLBotGUIX\Python37\python.exe" "%~dp0\update_venv.py"
+    "%AppDataPath%\RLBotGUIX\Python37\python.exe" "%~dp0\update_venv.py"
   )
 )
 
@@ -22,7 +39,7 @@ rem existing python installation that the user may have.
 
 if not exist .\venv\Scripts\activate.bat (
   echo Creating Python virtual environment just for RLBot...
-  "%LocalAppData%\RLBotGUIX\Python37\python.exe" -m venv .\venv
+  "%AppDataPath%\RLBotGUIX\Python37\python.exe" -m venv .\venv
   if %ERRORLEVEL% GTR 0 (
     echo Something went wrong with creating Python virtual environment, aborting.
     pause
@@ -35,10 +52,10 @@ call .\venv\Scripts\activate.bat
 
 echo Installing / upgrading RLBot components...
 
-pip install --upgrade pip
-pip install wheel
-pip install eel
-pip install --upgrade rlbot_gui rlbot
+python -m pip install -U pip
+pip install -U wheel
+pip install -U eel
+pip install -U rlbot_gui rlbot
 
 echo Launching RLBotGUI...
 


### PR DESCRIPTION
Also fixed the pip installation error - https://stackoverflow.com/questions/31172719/pip-install-access-denied-on-windows
If the registry key doesn't exist, then it will create the key and set it to `%LocalAppData%` (which is the default path as of right now)
`-U` is an alias for `--upgrade` - idk y I did this but I did :\

I have fully tested this. I successfully installed the RLBotGUI onto my micro sd card (mostly bc I also have my programming projects on it, so now I can have the RLBot virtual environment where ever I go now). It also properly installs to the default path.

It would be nice if there was a UI component that modified the registry entry, just to make this feature more user-friendly. (Extra -> Install path?)