### PR TITLE
Distinguish bots with identical names

### DIFF
--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -93,6 +93,10 @@ body, html {
   align-items: center;
 }
 
+.unique-bot-identifier {
+  color: #868686;
+}
+
 .script-card {
   background: linear-gradient(90deg, rgb(255, 255, 255) 0%, rgba(255, 255, 255, 0.34) 50%)
 }

--- a/rlbot_gui/gui/js/bot-card-vue.js
+++ b/rlbot_gui/gui/js/bot-card-vue.js
@@ -7,7 +7,7 @@ export default {
             <slot>
                 <img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
                 <img v-if="bot.logo" v-bind:src="bot.logo">
-                <span class="bot-name">{{ bot.name }}</span>
+                <span class="bot-name">{{ bot.name }} <span v-if="bot.uniquePathSegment" class="unique-bot-identifier">({{ bot.uniquePathSegment }})</span></span>
             </slot>
 
             <b-button size="sm" class="icon-button warning-icon" v-if="bot.warn" variant="outline-warning"

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -585,6 +585,7 @@ export default {
 
 			this.botPool = this.botPool.concat(freshBots).sort((a, b) => a.name.localeCompare(b.name));
 			this.applyLanguageWarnings();
+			this.distinguishDuplicateBots();
 			this.showProgressSpinner = false;
 		},
 
@@ -616,6 +617,32 @@ export default {
 				});
 			}
 		},
+		
+		distinguishDuplicateBots: function() {
+			const uniqueNames = [...new Set(this.botPool.map(bot => bot.name))];
+			const splitPath = bot => bot.path.split(/[\\|\/]/).reverse();
+
+			for (const name of uniqueNames) {
+				const bots = this.botPool.filter(bot => bot.name == name);
+				if (bots.length == 1) {
+					bots[0].uniquePathSegment = null;
+					continue;
+				}
+				for (let i = 0; bots.length > 0 && i < 99; i++) {
+					const pathSegments = bots.map(b => splitPath(b)[i]);
+
+					for (const bot of bots.slice()) {
+						const path = splitPath(bot);
+						const count = pathSegments.filter(s => s == path[i]).length;
+						if (count == 1) {
+							bot.uniquePathSegment = path[i];
+							bots.splice(bots.indexOf(bot), 1);
+						}
+					}
+				}
+			}
+		},
+
 		matchOptionsReceived: function(matchOptions) {
 			this.matchOptions = matchOptions;
 		},

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -1,6 +1,7 @@
 import AppearanceEditor from './appearance-editor-vue.js'
 import MutatorField from './mutator-field-vue.js'
 import BotCard from './bot-card-vue.js'
+import TeamCard from './team-card-vue.js'
 import LauncherPreferenceModal from './launcher-preference-vue.js'
 
 const HUMAN = {'name': 'Human', 'type': 'human', 'image': 'imgs/human.png'};
@@ -140,39 +141,15 @@ export default {
 
 		<b-row>
 			<b-col>
-				<b-card class="blu team-card md-elevation-8">
-					<div class="team-label">
-						<b-form-radio v-model="teamSelection" name="team-radios" value="blue">Add to Blue Team</b-form-radio>
-					</div>
-					<draggable v-model="blueTeam" class="team-entries" :options="{group:'bots'}">
-						<b-card class="bot-card draggable center-flex md-elevation-3" v-for="(bot, index) in blueTeam">
-							<img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
-							<img v-if="bot.logo" v-bind:src="bot.logo">
-							<span class="bot-name">{{ bot.name }}</span>
-							<b-button size="sm" variant="outline-danger" class="icon-button" @click="blueTeam.splice(index, 1)">
-								<b-icon icon="x"></b-icon>
-							</b-button>
-						</b-card>
-					</draggable>
-				</b-card>
+				<team-card :team="blueTeam" team-class="blu">
+					<b-form-radio v-model="teamSelection" name="team-radios" value="blue">Add to Blue Team</b-form-radio>
+				</team-card>
 			</b-col>
 
 			<b-col>
-				<b-card class="org team-card md-elevation-8">
-					<div class="team-label">
-						<b-form-radio v-model="teamSelection" name="team-radios" value="orange">Add to Orange Team</b-form-radio>
-					</div>
-					<draggable v-model="orangeTeam" class="team-entries" :options="{group:'bots'}">
-						<b-card class="bot-card draggable center-flex md-elevation-3" v-for="(bot, index) in orangeTeam">
-							<img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
-							<img v-if="bot.logo" v-bind:src="bot.logo">
-							<span class="bot-name">{{ bot.name }}</span>
-							<b-button size="sm" variant="outline-danger" class="icon-button" @click="orangeTeam.splice(index, 1)">
-								<b-icon icon="x"></b-icon>
-							</b-button>
-						</b-card>
-					</draggable>
-				</b-card>
+				<team-card :team="orangeTeam" team-class="org">
+					<b-form-radio v-model="teamSelection" name="team-radios" value="orange">Add to Orange Team</b-form-radio>
+				</team-card>
 			</b-col>
 		</b-row>
 
@@ -398,6 +375,7 @@ export default {
 		'mutator-field': MutatorField,
 		'bot-card': BotCard,
 		'launcher-preference-modal': LauncherPreferenceModal,
+		'team-card': TeamCard,
 	},
 	data () {
 		return {

--- a/rlbot_gui/gui/js/team-card-vue.js
+++ b/rlbot_gui/gui/js/team-card-vue.js
@@ -1,0 +1,21 @@
+export default {
+	name: 'team-card',
+	props: ['team', 'team-class'],
+	template: `
+		<b-card class="team-card md-elevation-8" :class="teamClass">
+            <div class="team-label">
+                <slot></slot>
+            </div>
+            <draggable v-model="team" class="team-entries" :options="{group:'bots'}">
+                <b-card class="bot-card draggable center-flex md-elevation-3" v-for="(bot, index) in team">
+                    <img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
+                    <img v-if="bot.logo" v-bind:src="bot.logo">
+                    <span class="bot-name">{{ bot.name }}</span>
+                    <b-button size="sm" variant="outline-danger" class="icon-button" @click="team.splice(index, 1)">
+                        <b-icon icon="x"></b-icon>
+                    </b-button>
+                </b-card>
+            </draggable>
+        </b-card>
+	`,
+}

--- a/rlbot_gui/gui/js/team-card-vue.js
+++ b/rlbot_gui/gui/js/team-card-vue.js
@@ -10,7 +10,7 @@ export default {
                 <b-card class="bot-card draggable center-flex md-elevation-3" v-for="(bot, index) in team">
                     <img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
                     <img v-if="bot.logo" v-bind:src="bot.logo">
-                    <span class="bot-name">{{ bot.name }}</span>
+                    <span class="bot-name">{{ bot.name }} <span v-if="bot.uniquePathSegment" class="unique-bot-identifier">({{ bot.uniquePathSegment }})</span></span>
                     <b-button size="sm" variant="outline-danger" class="icon-button" @click="team.splice(index, 1)">
                         <b-icon icon="x"></b-icon>
                     </b-button>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.83'
+__version__ = '0.0.84'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
- refactored team cards into a component, to eliminate duplicate code
- when there are at least two bots with identical names, find the first parent folder with a unique name (could also be just the agent cfg file) and display it next to the bot names to distinguish them
- works for any number of identical bots
  ![image](https://user-images.githubusercontent.com/18472149/96375185-b88d9900-1177-11eb-8b33-1d30a21dcb5b.png)
- useful for example for testing different versions against each other
  ![image](https://user-images.githubusercontent.com/18472149/96375462-69486800-1179-11eb-860d-e7b80b29ba87.png)

