### PR TITLE
Add VirxERLU-CLib to rlbot-requirements.txt

### DIFF
--- a/pynsist_helpers/rlbot-requirements.txt
+++ b/pynsist_helpers/rlbot-requirements.txt
@@ -9,3 +9,6 @@ rlbot_gui
 
 # Chip's utilities - https://github.com/samuelpmish/RLUtilities/tree/master/RLUtilities
 RLUtilities
+
+# VirxERLU's C Library - https://github.com/VirxEC/VirxERLU
+VirxERLU-CLib


### PR DESCRIPTION
I would say that TensorFlow and PyTorch should be added too, but TensorFlow is > 1GB, and PyTorch is finicky.

VirxERLU is small (only 30kb), and I've seen many users get confused at the scary yellow warning next to Abot and VirxEB.

So... pretty please?