### PR TITLE
New super-fast upgrading system

### DIFF
--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -210,6 +210,8 @@ class BotpackUpdater:
             return False
 
         releases_to_download = list(range(int(local_release_tag.replace("incr-", "")) + 1, int(latest_release["tag_name"].replace("incr-", "")) + 1))
+        if len(releases_to_download) > 10:
+            return "download"
 
         self.total_steps = len(releases_to_download) * 2
 

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -1,16 +1,20 @@
+import json
 import os
 import tempfile
+import time
 import urllib.request
 import zipfile
-import json
-import eel
-import time
 from pathlib import Path
 from shutil import rmtree
 from typing import Optional
 
+import eel
+from rlbot_gui.persistence.settings import load_settings
 
-def download_and_extract_zip(download_url: str, local_folder_path: Path,
+RELEASE_TAG = 'latest_botpack_release_tag'
+
+
+def download_and_extract_zip(download_url: str, local_folder_path: Path, local_subfolder_name: str,
                              clobber: bool = False, progress_callback: callable = None,
                              unzip_callback: callable = None):
     """
@@ -20,7 +24,11 @@ def download_and_extract_zip(download_url: str, local_folder_path: Path,
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         downloaded_zip_path = os.path.join(tmpdirname, 'downloaded.zip')
-        urllib.request.urlretrieve(download_url, downloaded_zip_path, progress_callback)
+        try:
+            urllib.request.urlretrieve(download_url, downloaded_zip_path, progress_callback)
+        except Exception as err:
+            print(err)
+            return False
 
         if clobber and os.path.exists(local_folder_path):
             rmtree(local_folder_path)
@@ -30,6 +38,37 @@ def download_and_extract_zip(download_url: str, local_folder_path: Path,
 
         with zipfile.ZipFile(downloaded_zip_path, 'r') as zip_ref:
             zip_ref.extractall(local_folder_path)
+
+        if not os.path.exists(os.path.join(local_folder_path, local_subfolder_name)):
+            folder_name = os.listdir(local_folder_path)[0]
+            os.rename(os.path.join(local_folder_path, folder_name), os.path.join(local_folder_path, local_subfolder_name))
+    return True
+
+
+def smart_upgrade(download_url: str, local_folder_path: Path, unzip_callback: callable = None):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        downloaded_zip_path = os.path.join(tmpdirname, 'downloaded.zip')
+        try:
+            urllib.request.urlretrieve(download_url, downloaded_zip_path)
+        except Exception as err:
+            print(err)
+            return False
+
+        if unzip_callback:
+            unzip_callback()
+
+        with zipfile.ZipFile(downloaded_zip_path, 'r') as zip_ref:
+            zip_ref.extractall(local_folder_path)
+
+        with open(local_folder_path / ".deleted", "r", encoding="utf-16") as deleted_ref:
+            files = deleted_ref.readlines()
+
+            for line in files:
+                if line.replace(" ", "").replace("\n", "") != "":
+                    file_name = local_folder_path / line.replace("\n", "")
+                    if os.path.isfile(file_name):
+                        os.remove(file_name)
+    return True
 
 
 def get_json_from_url(url):
@@ -87,7 +126,6 @@ class BotpackDownloader:
 
     def download(self, repo_owner: str, repo_name: str, branch_name: str, checkout_folder: Path):
         repo_full_name = repo_owner + '/' + repo_name
-        repo_url = 'https://github.com/' + repo_full_name
 
         self.status = f'Downloading {repo_full_name}-{branch_name}'
         print(self.status)
@@ -95,16 +133,85 @@ class BotpackDownloader:
 
         # Unfortunately we can't know the size of the zip file before downloading it,
         # so we have to get the size from the GitHub API.
-        self.estimated_zip_size = get_repo_size(repo_full_name) * 0.7
+        self.estimated_zip_size = get_repo_size(repo_full_name) * 0.65
 
         # If we fail to get the repo size, set it to a fallback value,
-        # so the progress bar will show atleast some progress.
-        # Let's assume the zip file is around 40 MB.
+        # so the progress bar will show at least some progress.
+        # Let's assume the zip file is around 70 MB.
         if not self.estimated_zip_size:
-            self.estimated_zip_size = 40_000_000
+            self.estimated_zip_size = 70_000_000
 
-        download_and_extract_zip(download_url=repo_url + '/archive/' + branch_name + '.zip',
+        try:
+            latest_release = get_json_from_url(f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest")
+        except Exception as err:
+            print(err)
+            return False
+
+        success = download_and_extract_zip(download_url=latest_release['zipball_url'],
                                  local_folder_path=checkout_folder,
+                                 local_subfolder_name=f"{repo_name}-{branch_name}",
                                  clobber=True,
                                  progress_callback=self.zip_download_callback,
                                  unzip_callback=self.unzip_callback)
+        
+        if success:
+            settings = load_settings()
+            settings.setValue(RELEASE_TAG, latest_release["tag_name"])
+
+        return success
+
+
+class BotpackUpdater:
+    """
+    Updates the botpack while updating the progress bar and status text.
+    """
+    def __init__(self):
+        self.status = ''
+
+        self.total_steps = 0
+        self.current_step = 0
+
+    def update_progressbar_and_status(self, status=None):
+        total_progress_percent = int(min(self.current_step / self.total_steps, 1) * 100)
+        if status is None: status = self.status
+        status = f'{status} ({total_progress_percent}%)'
+        eel.updateDownloadProgress(total_progress_percent, status)
+
+    def update(self, repo_owner: str, repo_name: str, branch_name: str, checkout_folder: Path):
+        repo_full_name = repo_owner + '/' + repo_name
+        repo_url = 'https://github.com/' + repo_full_name
+        master_folder = repo_name + "-" + branch_name
+
+        settings = load_settings()
+        local_release_tag = settings.value(RELEASE_TAG, type=str)
+
+        try:
+            latest_release = get_json_from_url(f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases/latest")
+        except Exception as err:
+            print(err)
+            return False
+
+        if local_release_tag == "" or not os.path.exists(os.path.join(checkout_folder, master_folder)):
+            return "download"
+
+        if local_release_tag == latest_release["tag_name"]:
+            print("The botpack is already up-to-date!")
+            return False
+
+        releases_to_download = list(range(int(local_release_tag.replace("incr-", "")) + 1, int(latest_release["tag_name"].replace("incr-", "")) + 1))
+
+        self.total_steps = len(releases_to_download) * 2
+
+        for tag in releases_to_download:
+            self.update_progressbar_and_status(f"Downloading incr-{tag}")
+            self.status = f"Applying changes from incr-{tag}"
+            self.current_step += 1
+            if not smart_upgrade(f"{repo_url}/releases/download/incr-{tag}/incremental.zip", Path(os.path.join(checkout_folder, master_folder)), self.update_progressbar_and_status):
+                print("Failed to complete botpack upgrade")
+                return False
+            # encase something goes wrong in the future, we can save our place between commit upgrades
+            settings.setValue(RELEASE_TAG, f"incr-{tag}")
+            self.current_step += 1
+        
+        self.update_progressbar_and_status(f"Done")
+        return True

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -14,6 +14,15 @@ from rlbot_gui.persistence.settings import load_settings
 RELEASE_TAG = 'latest_botpack_release_tag'
 
 
+def remove_empty_folders(root: Path):
+    for path, _, _ in list(os.walk(root))[::-1]:
+        if len(os.listdir(path)) == 0:
+            try:
+                os.remove(path)
+            except Exception:
+                continue
+
+
 def download_and_extract_zip(download_url: str, local_folder_path: Path, local_subfolder_name: str,
                              clobber: bool = False, progress_callback: callable = None,
                              unzip_callback: callable = None):
@@ -68,6 +77,8 @@ def smart_upgrade(download_url: str, local_folder_path: Path, unzip_callback: ca
                     file_name = local_folder_path / line.replace("\n", "")
                     if os.path.isfile(file_name):
                         os.remove(file_name)
+        
+        remove_empty_folders(local_folder_path)
     return True
 
 
@@ -172,7 +183,7 @@ class BotpackUpdater:
         self.current_step = 0
 
     def update_progressbar_and_status(self, status=None):
-        total_progress_percent = int(min(self.current_step / self.total_steps, 1) * 100)
+        total_progress_percent = int(min(self.current_step / self.total_steps, 1) * 100) if self.total_steps != 0 else 0
         if status is None: status = self.status
         status = f'{status} ({total_progress_percent}%)'
         eel.updateDownloadProgress(total_progress_percent, status)

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -20,7 +20,7 @@ def remove_empty_folders(root: Path):
     for path, _, _ in list(os.walk(root))[::-1]:
         if len(os.listdir(path)) == 0:
             try:
-                os.remove(path)
+                os.rmdir(path)
             except Exception:
                 continue
 

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -24,7 +24,7 @@ from rlbot.utils.requirements_management import install_requirements_file
 
 from rlbot_gui.bot_management.bot_creation import bootstrap_python_bot, bootstrap_scratch_bot, \
     bootstrap_python_hivemind, convert_to_filename
-from rlbot_gui.bot_management.downloader import BotpackDownloader, BotpackUpdater, get_json_from_url
+from rlbot_gui.bot_management.downloader import BotpackStatus, BotpackDownloader, BotpackUpdater, get_json_from_url
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, \
     do_infinite_loop_content, spawn_car_in_showroom, set_game_state, fetch_game_tick_packet
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
@@ -457,16 +457,8 @@ def get_content_folder():
     return Path(os.getcwd())
 
 
-
-@eel.expose
-def download_bot_pack():
-    content_folder = get_content_folder()
-    botpack_location = content_folder / BOTPACK_FOLDER
-
-    # The bot pack in now hosted at https://github.com/RLBot/RLBotPack
-    success = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
-
-    if success:
+def update_gui_after_botpack_update(botpack_location, botpack_status):
+    if botpack_status is BotpackStatus.SUCCESS:
         # Configure the folder settings.
         bot_folder_settings['folders'][str(botpack_location)] = {'visible': True}
 
@@ -475,28 +467,25 @@ def download_bot_pack():
         settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
         settings.sync()
         scan_for_bots()
+
+
+@eel.expose
+def download_bot_pack():
+    botpack_location = get_content_folder() / BOTPACK_FOLDER
+    botpack_status = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+    
+    update_gui_after_botpack_update(botpack_location, botpack_status)
 
 
 @eel.expose
 def update_bot_pack():
-    content_folder = get_content_folder()
-    botpack_location = content_folder / BOTPACK_FOLDER
+    botpack_location = get_content_folder() / BOTPACK_FOLDER
+    botpack_status = BotpackUpdater().update(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
 
-    # The bot pack in now hosted at https://github.com/RLBot/RLBotPack
-    success = BotpackUpdater().update(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+    if botpack_status == BotpackStatus.REQUIRES_FULL_DOWNLOAD:
+        botpack_status = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
 
-    if success == "download":
-        success = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
-
-    if success:
-        # Configure the folder settings.
-        bot_folder_settings['folders'][str(botpack_location)] = {'visible': True}
-
-        settings = load_settings()
-        settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
-        settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
-        settings.sync()
-        scan_for_bots()
+    update_gui_after_botpack_update(botpack_location, botpack_status)
 
 
 @eel.expose

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -474,6 +474,7 @@ def download_bot_pack():
         settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
         settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
         settings.sync()
+        scan_for_bots()
 
 
 @eel.expose
@@ -495,6 +496,7 @@ def update_bot_pack():
         settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
         settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
         settings.sync()
+        scan_for_bots()
 
 
 @eel.expose

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -24,7 +24,7 @@ from rlbot.utils.requirements_management import install_requirements_file
 
 from rlbot_gui.bot_management.bot_creation import bootstrap_python_bot, bootstrap_scratch_bot, \
     bootstrap_python_hivemind, convert_to_filename
-from rlbot_gui.bot_management.downloader import BotpackDownloader, get_json_from_url
+from rlbot_gui.bot_management.downloader import BotpackDownloader, BotpackUpdater, get_json_from_url
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, \
     do_infinite_loop_content, spawn_car_in_showroom, set_game_state, fetch_game_tick_packet
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
@@ -464,15 +464,37 @@ def download_bot_pack():
     botpack_location = content_folder / BOTPACK_FOLDER
 
     # The bot pack in now hosted at https://github.com/RLBot/RLBotPack
-    BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+    success = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
 
-    # Configure the folder settings.
-    bot_folder_settings['folders'][str(botpack_location)] = {'visible': True}
+    if success:
+        # Configure the folder settings.
+        bot_folder_settings['folders'][str(botpack_location)] = {'visible': True}
 
-    settings = load_settings()
-    settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
-    settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
-    settings.sync()
+        settings = load_settings()
+        settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
+        settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
+        settings.sync()
+
+
+@eel.expose
+def update_bot_pack():
+    content_folder = get_content_folder()
+    botpack_location = content_folder / BOTPACK_FOLDER
+
+    # The bot pack in now hosted at https://github.com/RLBot/RLBotPack
+    success = BotpackUpdater().update(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+
+    if success == "download":
+        success = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+
+    if success:
+        # Configure the folder settings.
+        bot_folder_settings['folders'][str(botpack_location)] = {'visible': True}
+
+        settings = load_settings()
+        settings.setValue(BOT_FOLDER_SETTINGS_KEY, bot_folder_settings)
+        settings.setValue(COMMIT_ID_KEY, get_last_botpack_commit_id())
+        settings.sync()
 
 
 @eel.expose

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -54,6 +54,9 @@ export default {
 					Menu
 				</template>
 
+				<b-dropdown-item @click="downloadBotPack()">
+					Repair bot pack
+				</b-dropdown-item>
 				<b-dropdown-item v-b-modal.package-installer>
 					Install missing python package
 				</b-dropdown-item>
@@ -90,10 +93,6 @@ export default {
 					<b-dropdown-item  @click="updateBotPack()">
 						<b-icon icon="cloud-download"></b-icon>
 						<span>Download Bot Pack</span>
-					</b-dropdown-item>
-					<b-dropdown-item  @click="downloadBotPack()">
-						<b-icon icon="hammer"></b-icon>
-						<span>Repair Bot Pack</span>
 					</b-dropdown-item>
 					<b-dropdown-item v-b-modal.new-bot-modal>
 						<b-icon icon="pencil-square"></b-icon>

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -87,9 +87,13 @@ export default {
 				<span class="rlbot-card-header">Player Types</span>
 				<b-dropdown class="ml-2 mr-2">
 					<template v-slot:button-content><b-icon icon="plus"/>Add</template>
-					<b-dropdown-item  @click="downloadBotPack()">
+					<b-dropdown-item  @click="updateBotPack()">
 						<b-icon icon="cloud-download"></b-icon>
 						<span>Download Bot Pack</span>
+					</b-dropdown-item>
+					<b-dropdown-item  @click="downloadBotPack()">
+						<b-icon icon="hammer"></b-icon>
+						<span>Repair Bot Pack</span>
 					</b-dropdown-item>
 					<b-dropdown-item v-b-modal.new-bot-modal>
 						<b-icon icon="pencil-square"></b-icon>
@@ -241,7 +245,7 @@ export default {
 		</b-toast>
 
 		<b-toast id="bot-pack-available-toast" v-model="showBotpackUpdateSnackbar" title="Bot Pack Update Available!" toaster="b-toaster-bottom-center">
-			<b-button variant="primary" @click="downloadBotPack()" style="margin-left: auto;">Download</b-button>
+			<b-button variant="primary" @click="updateBotPack()" style="margin-left: auto;">Download</b-button>
 		</b-toast>
 
 		<b-modal id="bot-info-modal" size="xl" :title="activeBot.name" v-if="activeBot && activeBot.info" hide-footer centered>
@@ -518,6 +522,13 @@ export default {
 			this.downloadProgressPercent = 0;
 			eel.download_bot_pack()(this.botPackDownloaded);
 		},
+		updateBotPack: function() {
+			this.showBotpackUpdateSnackbar = false;
+			this.$bvModal.show('bot-pack-download-modal');
+			this.downloadStatus = "Starting";
+			this.downloadProgressPercent = 0;
+			eel.update_bot_pack()(this.botPackUpdated);
+		},
 		showAppearanceEditor: function(looksPath) {
 			this.appearancePath = looksPath;
 			this.appearancePath = looksPath;
@@ -675,6 +686,15 @@ export default {
 
 		botPackDownloaded: function (response) {
 			this.snackbarContent = 'Downloaded Bot Pack!';
+			this.showSnackbar = true;
+			this.$bvModal.hide('bot-pack-download-modal');
+			eel.get_folder_settings()(this.folderSettingsReceived);
+			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived);
+			eel.get_recommendations()(recommendations => this.recommendations = recommendations);
+		},
+
+		botPackUpdated: function (response) {
+			this.snackbarContent = 'Updated Bot Pack!';
 			this.showSnackbar = true;
 			this.$bvModal.hide('bot-pack-download-modal');
 			eel.get_folder_settings()(this.folderSettingsReceived);


### PR DESCRIPTION
In order for this to work, RLBot/RLBotPack#118 needs to be committed.

## Problem

The botpack is currently getting quite big, and not a small portion of our users use RLBot because they have slow internet. So, we should really avoid re-downloading the botpack every time. This is also annoying for people with high-speed internet, as Github limited bandwidth quite a bit - not to mention that unzipping the whole botpack can take a hot second.

## Solution

This only downloads the required files. Every commit, appveyor makes a release with a zip file called `incremental.zip` - This is all of the changed files in the commit, along with a `.deleted` file that has a list of the deleted files. This zip is many, many times smaller than downloading the whole botpack would be. This results in faster download and extract times.

## UI integration

![image](https://user-images.githubusercontent.com/35614515/104249752-0abe1d80-543a-11eb-89f7-fc27aac481e7.png)
![image](https://user-images.githubusercontent.com/35614515/104249794-1dd0ed80-543a-11eb-92f1-68fe6b681b10.png)

+ Download Bot Pack will either download the botpack if the user hasn't already, or it will use the new upgrade system
+ Repair Bot Pack forces the GUI to redownload the botpack, in full

Download Bot Pack is meant to be to go-to for downloading/updating the botpack at any time, so it's presented as such.

## Speed

### Current speed

https://user-images.githubusercontent.com/35614515/104245710-c1b69b00-5432-11eb-9c25-c1fdf9e7a3f8.mp4

Downloading the full botpack takes me 13 seconds, on an AMD 4800H with gigabit ethernet. Wow, so incredibly slow!

### New update speed

Information on update (https://github.com/L0laapk3/RLBotPack/releases):

+ The botpack was updated from `incr-0` to `incr-13`
+ This update removes a ton a folders & adds a ton more, totaling to 950KB (zipped). Cryo's, Kamael's, and Bumblebee's files were moved around.

https://user-images.githubusercontent.com/35614515/104314502-8a360600-54a7-11eb-92ee-04d1934ea4af.mp4

Using the new update method, this takes 3 seconds to initialize, and *just 1 second download and extract*.