### PR TITLE
Add Support for Custom Maps

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -27,6 +27,7 @@ from rlbot_gui.bot_management.bot_creation import bootstrap_python_bot, bootstra
 from rlbot_gui.bot_management.downloader import BotpackDownloader, get_json_from_url
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, \
     do_infinite_loop_content, spawn_car_in_showroom, set_game_state, fetch_game_tick_packet
+from rlbot_gui.match_runner.custom_maps import find_all_custom_maps
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
 from rlbot_gui.persistence.settings import load_settings, BOT_FOLDER_SETTINGS_KEY, MATCH_SETTINGS_KEY, \
     LAUNCHER_SETTINGS_KEY, TEAM_SETTINGS_KEY, load_launcher_settings, launcher_preferences_from_map
@@ -365,7 +366,7 @@ def get_language_support():
 @eel.expose
 def get_match_options():
     return {
-        'map_types': map_types,
+        'map_types': map_types + find_all_custom_maps(),
         'game_modes': game_mode_types,
         'match_behaviours': existing_match_behavior_types,
         'mutators': {

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -663,6 +663,7 @@ export default {
 			this.folderSettings = folderSettings;
 			eel.scan_for_bots()(this.botsReceived);
 			eel.scan_for_scripts()(this.scriptsReceived);
+			eel.get_match_options()(this.matchOptionsReceived)
 		},
 
 		botpackPreExistingReceived: function(commit_id) {

--- a/rlbot_gui/match_runner/custom_maps.py
+++ b/rlbot_gui/match_runner/custom_maps.py
@@ -1,0 +1,92 @@
+"""
+Helpers to load and set up matches in custom maps
+"""
+
+from contextlib import contextmanager
+from datetime import datetime
+from os import path
+
+import shutil
+
+from rlbot.setup_manager import (
+    SetupManager,
+    RocketLeagueLauncherPreference,
+    try_get_steam_executable_path,
+)
+from rlbot.gamelaunch.epic_launch import locate_epic_games_launcher_rocket_league_binary
+from rlbot.utils import logging_utils
+
+CUSTOM_MAP_TARGET = {"filename": "Labs_Utopia_P.upk", "game_map": "UtopiaRetro"}
+
+logger = logging_utils.get_logger("custom_maps")
+
+
+@contextmanager
+def prepare_custom_map(custom_map_file: str, rl_directory: str):
+    """
+    Provides a context manager. It will swap out the custom_map_file
+    for an existing map in RL and it will return the `game_map`
+    name that should be used in a MatchConfig.
+
+    Once the context is left, the original map is replaced back.
+    The context should be left as soon as the match has started
+    """
+    real_map_file = path.join(rl_directory, CUSTOM_MAP_TARGET["filename"])
+    timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    temp_filename = real_map_file + "." + timestamp
+
+    shutil.copy2(real_map_file, temp_filename)
+    logger.info("Copied real map to %s", temp_filename)
+    shutil.copy2(custom_map_file, real_map_file)
+    logger.info("Copied custom map from %s", custom_map_file)
+
+    try:
+        yield CUSTOM_MAP_TARGET["game_map"]
+    finally:
+        shutil.move(temp_filename, real_map_file)
+        logger.info("Reverted real map to %s", real_map_file)
+
+
+def convert_custom_map_to_path(custom_map: str):
+    custom_map_dir = get_custom_map_dir()
+    custom_map_file = path.join(custom_map_dir, custom_map)
+    if not path.exists(custom_map_file):
+        logger.warning("%s - map doesn't exist", custom_map_file)
+        return None
+
+    return custom_map_file
+
+
+def get_custom_map_dir():
+    """Probably will get from storage or something?"""
+    custom_map_dir = r"C:\Users\Triton\Downloads\Simplicity"  # temp hardcoding
+    return custom_map_dir
+
+
+def identify_map_directory(launcher_pref: RocketLeagueLauncherPreference):
+    """Find RocketLeague map directory"""
+    final_path = None
+    if launcher_pref.preferred_launcher == RocketLeagueLauncherPreference.STEAM:
+        steam = try_get_steam_executable_path()
+        suffix = r"steamapps\common\rocketleague\TAGame\CookedPCConsole"
+        if not steam:
+            return None
+
+        # TODO: Steam can install RL on a different disk. Need to
+        # read libraryfolders.vdf to detect this situation
+        # It's a human-readable but custom format so not trivial to parse
+
+        final_path = path.join(path.dirname(steam), suffix)
+    else:
+        rl_executable = locate_epic_games_launcher_rocket_league_binary()
+        suffix = r"TAGame\CookedPCConsole"
+        if not rl_executable:
+            return None
+
+        # Binaries/Win64/ is what we want to strip off
+        final_path = path.join(path.dirname(rl_executable), "..", "..", suffix)
+
+    if not path.exists(final_path):
+        logger.warning("%s - directory doesn't exist", final_path)
+        return None
+    return final_path

--- a/rlbot_gui/match_runner/custom_maps.py
+++ b/rlbot_gui/match_runner/custom_maps.py
@@ -70,6 +70,15 @@ def convert_custom_map_to_path(custom_map: str) -> Optional[str]:
     return custom_map_file
 
 
+def find_all_custom_maps() -> List[str]:
+    folders = get_search_folders()
+    maps = []
+    for folder in folders:
+        scan_query = path.join(glob.escape(folder), "**", "*.upk")
+        maps.extend(path.basename(i) for i in glob.iglob(scan_query))
+    return maps
+
+
 def get_search_folders() -> List[str]:
     """Get all folders to search for maps"""
     bot_folders = load_settings().value(BOT_FOLDER_SETTINGS_KEY, type=dict)

--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -15,14 +15,6 @@
                     "map": "BeckwithPark",
                     "disabledBoost": true,
                     "display": "Win something so we know you can drive"
-                },
-                {
-                    "id": "INTRO-2",
-                    "humanTeamSize": 1,
-                    "opponentBots": ["adversity"],
-                    "map": "Simplicity.upk",
-                    "max_score": "1 Goal",
-                    "display": "Custom Map world!"
                 }
             ]
         },

--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -15,6 +15,15 @@
                     "map": "BeckwithPark",
                     "disabledBoost": true,
                     "display": "Win something so we know you can drive"
+                },
+                {
+                    "id": "INTRO-2",
+                    "humanTeamSize": 1,
+                    "opponentBots": ["adversity"],
+                    "map": "Simplicity.upk",
+                    "customMap": true,
+                    "max_score": "1 Goal",
+                    "display": "Custom Map world!"
                 }
             ]
         },

--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -21,7 +21,6 @@
                     "humanTeamSize": 1,
                     "opponentBots": ["adversity"],
                     "map": "Simplicity.upk",
-                    "customMap": true,
                     "max_score": "1 Goal",
                     "display": "Custom Map world!"
                 }

--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -29,12 +29,8 @@ from rlbot.matchconfig.match_config import (
 )
 from rlbot.setup_manager import SetupManager, RocketLeagueLauncherPreference
 
-from rlbot_gui.match_runner.match_runner import get_fresh_setup_manager
-from rlbot_gui.match_runner.custom_maps import (
-    prepare_custom_map,
-    identify_map_directory,
-    convert_custom_map_to_path
-)
+from rlbot_gui.match_runner.match_runner import get_fresh_setup_manager, setup_match
+
 
 from rlbot_gui import gui as rlbot_gui  # TODO: Need to remove circular import
 
@@ -447,16 +443,7 @@ def manage_game_state(
 
     return calculate_completion(challenge, stats_tracker.stats, results), results
 
-def setup_match(
-    setup_manager: SetupManager, match_config: MatchConfig, launcher_pref: RocketLeagueLauncherPreference
-):
-    """Starts the match and bots"""
-    setup_manager.early_start_seconds = 5
-    setup_manager.connect_to_game(launcher_preference=launcher_pref)
-    setup_manager.load_match_config(match_config)
-    setup_manager.launch_early_start_bot_processes()
-    setup_manager.start_match()
-    setup_manager.launch_bot_processes()
+
 
 
 def run_challenge(
@@ -464,20 +451,7 @@ def run_challenge(
 ) -> Tuple[bool, dict]:
     """Launch the game and keep track of the state"""
     setup_manager = get_fresh_setup_manager()
-
-    if challenge.get("customMap", False):
-        map_file = convert_custom_map_to_path(challenge["map"])
-        rl_directory = identify_map_directory(launcher_pref)
-
-        if not all([map_file, rl_directory]):
-            print("Couldn't load custom map")
-            return False, {}
-
-        with prepare_custom_map(map_file, rl_directory) as game_map:
-            match_config.game_map = game_map
-            setup_match(setup_manager, match_config, launcher_pref)
-    else:
-        setup_match(setup_manager, match_config, launcher_pref)
+    setup_match(setup_manager, match_config, launcher_pref)
 
     setup_manager.game_interface.renderer.clear_screen(RENDERING_GROUP)
     game_results = None


### PR DESCRIPTION
The long term plans are to create MapPack and leverage it in Story Mode but I think landing this allows us to provide a usable feature and also lets us test out the workflows earlier. It will also be useful for future map makers to easily test out maps with our bots.

A user can do Add -> Add a folder to select a folder with custom maps (`*.upk`) files anywhere in the directory. When the folder is added, the match options settings will show all the custom maps it found with the file suffix. The user can select it and play on it like any other map with/without bots.

### Implementation

We implement the custom map support by "swapping" out the custom map with "Labs_Utopia_P" in the user's RL install directory. As soon as the match is loaded, we swap the original file back to minimize any negative impact.
We support both Steam and Epic users (though Steam users with installs on a different drive are not currently supported).
