### PR TITLE
Support "helper scripts" for custom maps

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -345,11 +345,17 @@ def try_copy_logo(bundle: RunnableConfigBundle):
 
 
 def get_bots_from_directory(bot_directory):
-    return [serialize_bundle(bundle) for bundle in scan_directory_for_bot_configs(bot_directory)]
+    bundles = filter_hidden_bundles(scan_directory_for_bot_configs(bot_directory))
+    return [serialize_bundle(bundle) for bundle in bundles]
 
 
 def get_scripts_from_directory(bot_directory):
-    return [serialize_script_bundle(bundle) for bundle in scan_directory_for_script_configs(bot_directory)]
+    bundles = filter_hidden_bundles(scan_directory_for_script_configs(bot_directory))
+    return [serialize_script_bundle(bundle) for bundle in bundles]
+
+
+def filter_hidden_bundles(bundles):
+    return [bundle for bundle in bundles if not bundle.config_file_name.startswith("_")]
 
 
 @eel.expose

--- a/rlbot_gui/match_runner/custom_maps.py
+++ b/rlbot_gui/match_runner/custom_maps.py
@@ -36,6 +36,17 @@ def prepare_custom_map(custom_map_file: str, rl_directory: str):
     Once the context is left, the original map is replaced back.
     The context should be left as soon as the match has started
     """
+
+    # check if there metadata for the custom file
+    expected_config_name = "_" + path.basename(custom_map_file)[:-4] + ".cfg"
+    config_path = path.join(path.dirname(custom_map_file), expected_config_name)
+    additional_info = {
+        "original_path": custom_map_file,
+    }
+    if path.exists(config_path):
+        additional_info["config_path"] = config_path
+
+
     real_map_file = path.join(rl_directory, CUSTOM_MAP_TARGET["filename"])
     timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
     temp_filename = real_map_file + "." + timestamp
@@ -46,7 +57,7 @@ def prepare_custom_map(custom_map_file: str, rl_directory: str):
     logger.info("Copied custom map from %s", custom_map_file)
 
     try:
-        yield CUSTOM_MAP_TARGET["game_map"]
+        yield CUSTOM_MAP_TARGET["game_map"], additional_info
     finally:
         shutil.move(temp_filename, real_map_file)
         logger.info("Reverted real map to %s", real_map_file)

--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -159,8 +159,13 @@ def setup_match(
             print("Couldn't load custom map")
             return
 
-        with prepare_custom_map(map_file, rl_directory) as game_map:
+        with prepare_custom_map(map_file, rl_directory) as (game_map, metadata):
             match_config.game_map = game_map
+            if "config_path" in metadata:
+                config_path = metadata["config_path"]
+                match_config.script_configs.append(
+                    create_script_config({'path': config_path}))
+                print(f"Will load custom script for map {config_path}")
             do_setup()
     else:
         do_setup()


### PR DESCRIPTION
This PR adds logic to ignore `*.cfg` files that start with `_`. This in general will allow us to add hidden bots and scripts that can be used in Story Mode without cluttering the UI.

We use this feature to also add script support for custom maps.