### PR TITLE
Use os.replace to overwrite existing map file

### DIFF
--- a/rlbot_gui/match_runner/custom_maps.py
+++ b/rlbot_gui/match_runner/custom_maps.py
@@ -10,6 +10,7 @@ from typing import List, Optional
 
 import glob
 import shutil
+import os
 
 from rlbot.setup_manager import (
     SetupManager,
@@ -59,7 +60,7 @@ def prepare_custom_map(custom_map_file: str, rl_directory: str):
     try:
         yield CUSTOM_MAP_TARGET["game_map"], additional_info
     finally:
-        shutil.move(temp_filename, real_map_file)
+        os.replace(temp_filename, real_map_file)
         logger.info("Reverted real map to %s", real_map_file)
 
 


### PR DESCRIPTION
shutil.move is supposed to raise an exception if the destination
file already exists. However, I didn't run into it in testing
because it is currently a bug in shutil:
https://bugs.python.org/issue42929

So depending on the version of shutil you get, you may or may
not run into this.

The correct implementation is to use os.replace to atomically
delete (if already exists) and move.