### PR TITLE
Address minor concerns with number of download threads for incremental patching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.96'
+__version__ = '0.0.97'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
I have some minor concerns with changes made to [L0laapk3/RLBotGUI/multithreaded-downloads](https://github.com/L0laapk3/RLBotGUI/tree/multithreaded-downloads).

Mainly that the threads spawned by the pool only serve to initiate and collect the downloads, and it does not make sense to scale them with the number of cpu cores available. All the CPU intensive work is still done on the main thread. For the same reasons it also doesn't make much sense to limit the threshold number of patches before full redownload based on cpu cores available.

The numbers I chose are arbitrary, but I don't think it is a good idea to scale them off of cpu cores.