### PR TITLE
Use story-mode specific version of blind-and-deaf

### DIFF
--- a/rlbot_gui/story/bots-base.json
+++ b/rlbot_gui/story/bots-base.json
@@ -47,7 +47,7 @@
     "baf": {
         "name": "BAF",
         "type": "rlbot",
-        "path": ["$RLBOTPACKROOT", "RLBotPack", "blind_and_deaf", "bot.cfg"]
+        "path": ["$RLBOTPACKROOT", "RLBotPack", "blind_and_deaf", "_story_mode_bot.cfg"]
     },
     "tbd": {
         "name": "Psyonix Allstar",

--- a/rlbot_gui/story/bots-base.json
+++ b/rlbot_gui/story/bots-base.json
@@ -45,7 +45,7 @@
         "path": ["$RLBOTPACKROOT", "RLBotPack", "Botimus&Bumblebee", "bumblebee.cfg"]
     },
     "baf": {
-        "name": "BAF",
+        "name": "Flying Panda",
         "type": "rlbot",
         "path": ["$RLBOTPACKROOT", "RLBotPack", "blind_and_deaf", "_story_mode_bot.cfg"]
     },


### PR DESCRIPTION
@Darxeal added an additional bot config that adds a weakness
to blind-and-deaf. This is a bit necessary since a recent
change in blind-and-deaf fixed some quirks which was the only way
to beat blind-and-deaf previously (but also provided for an
inconsistent experience). So hopefully this is a net positive.

I want to wait couple of days to see if any champ-and-up level players can try out
this config and provide some feedback.