### PR TITLE
Updating and Downloading RLBot MapPack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ RLBotPack.zip
 github-bot-pack.zip
 RLBotPack/
 RLBotPackDeletable/
+RLBotMapPackDeletable/
 MyBots/
 rlbot_gui/gui/imgs/logos
 

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -36,6 +36,21 @@ def remove_empty_folders(root: Path):
                 continue
 
 
+def get_map_revision(location, repo_name):
+    """
+    For a map pack, tells you the current revision
+    """
+    master_folder = repo_name + "-" + FOLDER_SUFFIX
+    index_path = Path(location) / master_folder / "index.json"
+
+    if index_path.exists():
+        with open(index_path) as file:
+            index = json.load(file)
+        
+        return index["revision"]
+
+
+
 def download_and_extract_zip(download_url: str, local_folder_path: Path, local_subfolder_name: str = None,
                              clobber: bool = False, progress_callback: callable = None,
                              unzip_callback: callable = None):
@@ -123,7 +138,7 @@ class RepoDownloader:
     def unzip_callback(self):
         eel.updateDownloadProgress(100, 'Extracting ZIP file')
 
-    def download(self, repo_owner: str, repo_name: str, checkout_folder: Path):
+    def download(self, repo_owner: str, repo_name: str, checkout_folder: Path, update_tag_setting=True):
         repo_full_name = repo_owner + '/' + repo_name
         folder_suffix = FOLDER_SUFFIX
 
@@ -154,7 +169,7 @@ class RepoDownloader:
                                  progress_callback=self.zip_download_callback,
                                  unzip_callback=self.unzip_callback)
         
-        if success is BotpackStatus.SUCCESS:
+        if success is BotpackStatus.SUCCESS and update_tag_setting:
             settings = load_settings()
             settings.setValue(RELEASE_TAG, latest_release["tag_name"])
 

--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -15,6 +15,7 @@ import eel
 from rlbot_gui.persistence.settings import load_settings
 
 RELEASE_TAG = 'latest_botpack_release_tag'
+FOLDER_SUFFIX = 'master'
 
 
 class BotpackStatus(Enum):
@@ -87,9 +88,9 @@ def get_repo_size(repo_full_name) -> Optional[int]:
         return None
 
 
-class BotpackDownloader:
+class RepoDownloader:
     """
-    Downloads the botpack while updating the progress bar and status text.
+    Downloads the given repo while updating the progress bar and status text.
     """
 
     PROGRESSBAR_UPDATE_INTERVAL = 0.1  # How often to update the progress bar (seconds)
@@ -122,10 +123,11 @@ class BotpackDownloader:
     def unzip_callback(self):
         eel.updateDownloadProgress(100, 'Extracting ZIP file')
 
-    def download(self, repo_owner: str, repo_name: str, branch_name: str, checkout_folder: Path):
+    def download(self, repo_owner: str, repo_name: str, checkout_folder: Path):
         repo_full_name = repo_owner + '/' + repo_name
+        folder_suffix = FOLDER_SUFFIX
 
-        self.status = f'Downloading {repo_full_name}-{branch_name}'
+        self.status = f'Downloading {repo_full_name}-{folder_suffix}'
         print(self.status)
         self.total_progress = 0
 
@@ -147,7 +149,7 @@ class BotpackDownloader:
 
         success = download_and_extract_zip(download_url=latest_release['zipball_url'],
                                  local_folder_path=checkout_folder,
-                                 local_subfolder_name=f"{repo_name}-{branch_name}",
+                                 local_subfolder_name=f"{repo_name}-{folder_suffix}",
                                  clobber=True,
                                  progress_callback=self.zip_download_callback,
                                  unzip_callback=self.unzip_callback)
@@ -187,10 +189,10 @@ class BotpackUpdater:
             return tag
 
 
-    def update(self, repo_owner: str, repo_name: str, branch_name: str, checkout_folder: Path):
+    def update(self, repo_owner: str, repo_name: str, checkout_folder: Path):
         repo_full_name = repo_owner + '/' + repo_name
         repo_url = 'https://github.com/' + repo_full_name
-        master_folder = repo_name + "-" + branch_name
+        master_folder = repo_name + "-" + FOLDER_SUFFIX
 
         settings = load_settings()
         local_release_tag = settings.value(RELEASE_TAG, type=str)

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -24,7 +24,7 @@ from rlbot.utils.requirements_management import install_requirements_file
 
 from rlbot_gui.bot_management.bot_creation import bootstrap_python_bot, bootstrap_scratch_bot, \
     bootstrap_python_hivemind, convert_to_filename
-from rlbot_gui.bot_management.downloader import BotpackStatus, BotpackDownloader, BotpackUpdater, get_json_from_url
+from rlbot_gui.bot_management.downloader import BotpackStatus, RepoDownloader, BotpackUpdater, get_json_from_url
 from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, start_match_helper, \
     do_infinite_loop_content, spawn_car_in_showroom, set_game_state, fetch_game_tick_packet
 from rlbot_gui.match_runner.custom_maps import find_all_custom_maps
@@ -38,10 +38,12 @@ from rlbot_gui.story import story_runner
 
 DEFAULT_BOT_FOLDER = 'default_bot_folder'
 BOTPACK_FOLDER = 'RLBotPackDeletable'
+MAPPACK_FOLDER = 'RLBotMapPackDeletable'
+MAPPACK_REPO = ("azeemba", "RLBotMapPack")
 OLD_BOTPACK_FOLDER = 'RLBotPack'
 BOTPACK_REPO_OWNER = 'RLBot'
 BOTPACK_REPO_NAME = 'RLBotPack'
-BOTPACK_REPO_BRANCH = 'master'
+BOTPACK_REPO_BRANCH = 'master' # can't change with the new release system
 CREATED_BOTS_FOLDER = 'MyBots'
 COMMIT_ID_KEY = 'latest_botpack_commit_id'
 bot_folder_settings = None
@@ -479,18 +481,30 @@ def update_gui_after_botpack_update(botpack_location, botpack_status):
 @eel.expose
 def download_bot_pack():
     botpack_location = get_content_folder() / BOTPACK_FOLDER
-    botpack_status = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+    botpack_status = RepoDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, botpack_location)
     
     update_gui_after_botpack_update(botpack_location, botpack_status)
 
 
 @eel.expose
+def update_map_pack():
+    location = get_content_folder() / MAPPACK_FOLDER
+    # status = BotpackUpdater().update(MAPPACK_REPO[0], MAPPACK_REPO[1], MAPPACK_REPO[2], location)
+    status = BotpackStatus.REQUIRES_FULL_DOWNLOAD
+
+    if status == BotpackStatus.REQUIRES_FULL_DOWNLOAD:
+        status = RepoDownloader().download(MAPPACK_REPO[0], MAPPACK_REPO[1], location)
+
+    # update_gui_after_botpack_update(botpack_location, botpack_status)
+
+
+@eel.expose
 def update_bot_pack():
     botpack_location = get_content_folder() / BOTPACK_FOLDER
-    botpack_status = BotpackUpdater().update(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+    botpack_status = BotpackUpdater().update(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, botpack_location)
 
     if botpack_status == BotpackStatus.REQUIRES_FULL_DOWNLOAD:
-        botpack_status = BotpackDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, BOTPACK_REPO_BRANCH, botpack_location)
+        botpack_status = RepoDownloader().download(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, botpack_location)
 
     update_gui_after_botpack_update(botpack_location, botpack_status)
 

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -14,7 +14,7 @@ const STARTING_BOT_POOL = [
 
 export default {
 	name: 'match-setup',
-	template: `
+	template: /*html*/`
 	<div>
 	<b-navbar class="navbar">
 		<b-navbar-brand>
@@ -97,6 +97,10 @@ export default {
 					<b-dropdown-item v-b-modal.new-bot-modal>
 						<b-icon icon="pencil-square"></b-icon>
 						<span>Start Your Own Bot!</span>
+					</b-dropdown-item>
+					<b-dropdown-item @click="updateMapPack()">
+						<b-icon icon="geo"></b-icon>
+						<span>Download Maps</span>
 					</b-dropdown-item>
 					<b-dropdown-item  @click="pickBotFolder()">
 						<b-icon icon="folder-plus"></b-icon>
@@ -341,7 +345,7 @@ export default {
 
 		</b-modal>
 
-		<b-modal id="bot-pack-download-modal" title="Downloading Bot Pack" hide-footer centered no-close-on-backdrop no-close-on-esc hide-header-close>
+		<b-modal id="download-modal" v-bind:title="downloadModalTitle" hide-footer centered no-close-on-backdrop no-close-on-esc hide-header-close>
 			<div class="text-center">
 				<b-icon icon="cloud-download" font-scale="3"></b-icon>
 			</div>
@@ -440,6 +444,7 @@ export default {
 			botNameFilter: '',
 			appearancePath: '',
 			recommendations: null,
+			downloadModalTitle: "Downloading Bot Pack"
 		}
 	},
 
@@ -516,17 +521,27 @@ export default {
 		},
 		downloadBotPack: function() {
 			this.showBotpackUpdateSnackbar = false;
-			this.$bvModal.show('bot-pack-download-modal');
+			this.downloadModalTitle = "Downloading Bot Pack" 
+			this.$bvModal.show('download-modal');
 			this.downloadStatus = "Starting";
 			this.downloadProgressPercent = 0;
-			eel.download_bot_pack()(this.botPackDownloaded);
+			eel.download_bot_pack()(this.botPackUpdated.bind(this, 'Downloaded Bot Pack!'));
 		},
 		updateBotPack: function() {
 			this.showBotpackUpdateSnackbar = false;
-			this.$bvModal.show('bot-pack-download-modal');
+			this.downloadModalTitle = "Updating Bot Pack" 
+			this.$bvModal.show('download-modal');
 			this.downloadStatus = "Starting";
 			this.downloadProgressPercent = 0;
-			eel.update_bot_pack()(this.botPackUpdated);
+			eel.update_bot_pack()(this.botPackUpdated.bind(this, 'Updated Bot Pack!'));
+		},
+		updateMapPack: function() {
+			this.showBotpackUpdateSnackbar = false;
+			this.downloadModalTitle = "Downloading Custom Maps" 
+			this.$bvModal.show('download-modal');
+			this.downloadStatus = "Starting";
+			this.downloadProgressPercent = 0;
+			eel.update_map_pack()(this.botPackUpdated.bind(this, 'Downloaded Maps!'));
 		},
 		showAppearanceEditor: function(looksPath) {
 			this.appearancePath = looksPath;
@@ -684,19 +699,10 @@ export default {
 			this.showBotpackUpdateSnackbar = !isBotpackUpToDate;
 		},
 
-		botPackDownloaded: function (response) {
-			this.snackbarContent = 'Downloaded Bot Pack!';
+		botPackUpdated: function (message) {
+			this.snackbarContent = message;
 			this.showSnackbar = true;
-			this.$bvModal.hide('bot-pack-download-modal');
-			eel.get_folder_settings()(this.folderSettingsReceived);
-			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived);
-			eel.get_recommendations()(recommendations => this.recommendations = recommendations);
-		},
-
-		botPackUpdated: function (response) {
-			this.snackbarContent = 'Updated Bot Pack!';
-			this.showSnackbar = true;
-			this.$bvModal.hide('bot-pack-download-modal');
+			this.$bvModal.hide('download-modal');
 			eel.get_folder_settings()(this.folderSettingsReceived);
 			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived);
 			eel.get_recommendations()(recommendations => this.recommendations = recommendations);

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -706,6 +706,7 @@ export default {
 			eel.get_folder_settings()(this.folderSettingsReceived);
 			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived);
 			eel.get_recommendations()(recommendations => this.recommendations = recommendations);
+			eel.get_match_options()(this.matchOptionsReceived)
 		},
 
 		onInstallationComplete: function (result) {

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.100'
+__version__ = '0.0.101'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
The full workflow for updating the MapPack is this:

- Check if there is a newer release (using the revision number from `index.json`)
- If there is a new release, download the full repo
- Compare old and new `index.json` files 
  -  For maps that have an updated revision, download them

This is what the `index.json` file looks like in the map pack:

```json
{
    "revision": 3,
    "maps": [
        {
            "path": "Simplicity/Simplicity.upk",
            "revision": 3
        }
    ]
}
```

The code leverages some of the existing BotPack downloader logic and makes it more generic for use.

Currently the MapPack is located at [azeemba/RLBotMapPack](https://github.com/azeemba/RLBotMapPack) and here is an example release: [v3](https://github.com/azeemba/RLBotMapPack/releases/tag/v3). This [script ](https://github.com/azeemba/RLBotMapPack/blob/main/publish.py) is used to auto-publish the release which will update `index.json` and attach files to the release.

## Open Question
Are we okay with the repo being in my namespace? Or should we migrate this to RLBot before release this change?

## Screenshot

<img src="https://user-images.githubusercontent.com/2160795/106697469-d1964a80-65ac-11eb-8bdd-465a2140d297.png" height="200">


## Next Steps

There is more work that will happen here. The next step is to add "custom map" options and detection in Story Mode. However, I figured this was a good break-off point to have smaller PRs.
