### PR TITLE
Custom Map Integration for Story Mode

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -516,6 +516,14 @@ def update_map_pack():
 
 
 @eel.expose
+def get_map_pack_revision():
+    location = get_content_folder() / MAPPACK_FOLDER
+    updater = MapPackUpdater(location, MAPPACK_REPO[0], MAPPACK_REPO[1])
+    index = updater.get_map_index()
+    return index["revision"] if "revision" in index else None
+
+
+@eel.expose
 def update_bot_pack():
     botpack_location = get_content_folder() / BOTPACK_FOLDER
     botpack_status = BotpackUpdater().update(BOTPACK_REPO_OWNER, BOTPACK_REPO_NAME, botpack_location)

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -37,17 +37,11 @@ export default {
 				State setting is turned off, sandbox won't work!
 			</b-tooltip>
 
-			<span id="story-button-wrapper">
-				<b-button 
-					@click="$router.replace('/story')" variant="dark" class="ml-2"
-					:disabled="!botpackPreExisting">
-					Story Mode
-				</b-button>
-			</span>
-			<b-tooltip target="story-button-wrapper" v-if="!botpackPreExisting">
-				<b-icon class="warning-icon" icon="exclamation-triangle-fill"></b-icon>
-				Download the BotPack first!
-			</b-tooltip>
+			<b-button 
+				@click="$router.replace('/story')" variant="dark" class="ml-2"
+				>
+				Story Mode
+			</b-button>
 
 			<b-dropdown right class="ml-4" variant="dark">
 				<template v-slot:button-content>
@@ -437,7 +431,6 @@ export default {
 				files: {},
 				folders: {}
 			},
-			botpackPreExisting: false,
 			downloadProgressPercent: 0,
 			downloadStatus: '',
 			showBotpackUpdateSnackbar: false,
@@ -691,10 +684,6 @@ export default {
 			eel.get_match_options()(this.matchOptionsReceived)
 		},
 
-		botpackPreExistingReceived: function(commit_id) {
-			this.botpackPreExisting = Boolean(commit_id)
-		},
-
 		botpackUpdateChecked: function (isBotpackUpToDate) {
 			this.showBotpackUpdateSnackbar = !isBotpackUpToDate;
 		},
@@ -704,7 +693,6 @@ export default {
 			this.showSnackbar = true;
 			this.$bvModal.hide('download-modal');
 			eel.get_folder_settings()(this.folderSettingsReceived);
-			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived);
 			eel.get_recommendations()(recommendations => this.recommendations = recommendations);
 			eel.get_match_options()(this.matchOptionsReceived)
 		},
@@ -743,7 +731,6 @@ export default {
 				this.applyLanguageWarnings();
 			});
 
-			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived)
 			eel.is_botpack_up_to_date()(this.botpackUpdateChecked);
 			eel.get_recommendations()(recommendations => this.recommendations = recommendations);
 

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -729,6 +729,31 @@ export default {
 			this.orangeTeam = bots.slice();
 			this.$bvModal.hide('recommendations-modal');
 		},
+		startup: function() {
+			if (this.$route.path != "/") {
+				return
+			}
+			eel.get_folder_settings()(this.folderSettingsReceived);
+			eel.get_match_options()(this.matchOptionsReceived);
+			eel.get_match_settings()(this.matchSettingsReceived);
+			eel.get_team_settings()(this.teamSettingsReceived);
+
+			eel.get_language_support()((support) => {
+				this.languageSupport = support;
+				this.applyLanguageWarnings();
+			});
+
+			eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived)
+			eel.is_botpack_up_to_date()(this.botpackUpdateChecked);
+			eel.get_recommendations()(recommendations => this.recommendations = recommendations);
+
+			const self = this;
+			eel.expose(updateDownloadProgress);
+			function updateDownloadProgress(progress, status) {
+				self.downloadStatus = status;
+				self.downloadProgressPercent = progress;
+			}
+		}
 	},
 	computed: {
 		activeMutatorCount: function() {
@@ -738,25 +763,10 @@ export default {
 		},
 	},
 	created: function () {
-		eel.get_folder_settings()(this.folderSettingsReceived);
-		eel.get_match_options()(this.matchOptionsReceived);
-		eel.get_match_settings()(this.matchSettingsReceived);
-		eel.get_team_settings()(this.teamSettingsReceived);
-
-		eel.get_language_support()((support) => {
-			this.languageSupport = support;
-			this.applyLanguageWarnings();
-		});
-
-		eel.get_downloaded_botpack_commit_id()(this.botpackPreExistingReceived)
-		eel.is_botpack_up_to_date()(this.botpackUpdateChecked);
-		eel.get_recommendations()(recommendations => this.recommendations = recommendations);
-
-		const self = this;
-		eel.expose(updateDownloadProgress);
-		function updateDownloadProgress(progress, status) {
-			self.downloadStatus = status;
-			self.downloadProgressPercent = progress;
-		}
-	}
+		this.startup()
+	},
+	watch: {
+		// call again the method if the route changes
+		'$route': 'startup'
+	},
 };

--- a/rlbot_gui/gui/js/story-mode-start.js
+++ b/rlbot_gui/gui/js/story-mode-start.js
@@ -28,7 +28,7 @@ export default {
             <colorpicker v-model="form.teamcolor" text="Pick color"/>
         </b-form-group>
 
-        <b-form-group label="Use Custom Maps" label-cols="3">
+        <b-form-group label="Use Custom Maps" label-cols="3" v-if="false">
             <b-form-checkbox v-model="form.use_custom_maps" size="lg">
                 <small> May require large downloads</small>
             </b-form-checkbox>
@@ -70,7 +70,7 @@ export default {
                 custom_story: {
                     storyPath: ''
                 },
-                use_custom_maps: true
+                use_custom_maps: false
             },
             storyIdOptions: [
                 { value: "easy", text: "Easy"},

--- a/rlbot_gui/gui/js/story-mode-start.js
+++ b/rlbot_gui/gui/js/story-mode-start.js
@@ -29,14 +29,16 @@ export default {
         </b-form-group>
 
         <b-form-group label="Use Custom Maps" label-cols="3">
-            <b-form-checkbox v-model="form.use_custom_maps" size="lg"> </b-form-checkbox>
+            <b-form-checkbox v-model="form.use_custom_maps" size="lg">
+                <small> May require large downloads</small>
+            </b-form-checkbox>
         </b-form-group>
 
         <b-form-group label="Config" label-cols="3" >
             <b-form-select v-model="form.story_id" :options="storyIdOptions"/>
         </b-form-group>
 
-        <b-form-group label="Custom Story Config" v-if="form.story_id == 'custom'" label-class="font-weight-bold">
+        <b-form-group label="User Provided" v-if="form.story_id == 'custom'" label-class="font-weight-bold">
             <b-form-group label="Story Config" label-cols="3">
                 <b-button @click="pickFile" value="storyPath">Pick File</b-button>
                 <span>{{this.form.custom_story.storyPath}}</span>

--- a/rlbot_gui/gui/js/story-mode-start.js
+++ b/rlbot_gui/gui/js/story-mode-start.js
@@ -14,7 +14,7 @@ export default {
     <b-card>
     <b-card-text>
     <b-form @submit.prev="$emit('started', form)">
-        <b-form-group label="Teamname" label-for="teamname_entry" label-cols="auto">
+        <b-form-group label="Teamname" label-for="teamname_entry" label-cols="3">
             <b-form-input 
                 type="text"
                 required
@@ -24,11 +24,15 @@ export default {
 
         </b-form-group>
 
-        <b-form-group label="Team Color" label-cols="auto">
+        <b-form-group label="Team Color" label-cols="3">
             <colorpicker v-model="form.teamcolor" text="Pick color"/>
         </b-form-group>
 
-        <b-form-group label="Difficulty" label-cols="auto">
+        <b-form-group label="Use Custom Maps" label-cols="3">
+            <b-form-checkbox v-model="form.use_custom_maps" size="lg"> </b-form-checkbox>
+        </b-form-group>
+
+        <b-form-group label="Config" label-cols="3" >
             <b-form-select v-model="form.story_id" :options="storyIdOptions"/>
         </b-form-group>
 
@@ -39,7 +43,7 @@ export default {
             </b-form-group>
         </b-form-group>
         
-        <b-form-group label="Launcher" label-cols="auto">
+        <b-form-group label="Launcher" label-cols="3">
             <b-button v-b-modal.launcher-modal-story>
                 Choose Steam or Epic
             </b-button>
@@ -63,12 +67,13 @@ export default {
                 story_id: 'default',
                 custom_story: {
                     storyPath: ''
-                }
+                },
+                use_custom_maps: true
             },
             storyIdOptions: [
                 { value: "easy", text: "Easy"},
                 { value: "default", text: "Default"},
-                { value: "custom", text: "Custom"}
+                { value: "custom", text: "User Provided Config"}
             ]
         };
     },

--- a/rlbot_gui/gui/js/story-mode.js
+++ b/rlbot_gui/gui/js/story-mode.js
@@ -80,13 +80,14 @@ export default {
         },
         startStory: async function (event) {
             console.log(event);
-            team_settings = {
+            let team_settings = {
                 name: event.teamname,
                 color: event.teamcolor,
             }
-            story_settings = {
+            let story_settings = {
                 story_id: event.story_id,
-                custom_config: event.custom_story
+                custom_config: event.custom_story,
+                use_custom_maps: event.use_custom_maps
             }
             let state = await eel.story_new_save(team_settings, story_settings)();
             this.saveState = state;

--- a/rlbot_gui/gui/js/story-mode.js
+++ b/rlbot_gui/gui/js/story-mode.js
@@ -13,7 +13,7 @@ const UI_STATES = {
 
 export default {
     name: 'story',
-    template: `
+    template: /*html*/`
     <div>
     <b-navbar class="navbar">
         <b-navbar-brand>
@@ -80,11 +80,15 @@ export default {
         },
         startStory: async function (event) {
             console.log(event);
-            let state = await eel.story_new_save(
-                event.teamname,
-                event.teamcolor,
-                event.story_id,
-                event.custom_story)();
+            team_settings = {
+                name: event.teamname,
+                color: event.teamcolor,
+            }
+            story_settings = {
+                story_id: event.story_id,
+                custom_config: event.custom_story
+            }
+            let state = await eel.story_new_save(team_settings, story_settings)();
             this.saveState = state;
             this.storyStateMachine(UI_STATES.STORY_CHALLENGES);
         },

--- a/rlbot_gui/match_runner/custom_maps.py
+++ b/rlbot_gui/match_runner/custom_maps.py
@@ -83,11 +83,18 @@ def convert_custom_map_to_path(custom_map: str) -> Optional[str]:
 
 
 def find_all_custom_maps() -> List[str]:
+    """
+    Ignores maps starting with _
+    """
     folders = get_search_folders()
     maps = []
     for folder in folders:
         scan_query = path.join(glob.escape(folder), "**", "*.upk")
-        maps.extend(path.basename(i) for i in glob.iglob(scan_query, recursive=True))
+        for match in glob.iglob(scan_query, recursive=True):
+            basename = path.basename(match)
+            if basename.startswith("_"):
+                continue
+            maps.append(basename)
     return maps
 
 

--- a/rlbot_gui/story/load_story_descriptions.py
+++ b/rlbot_gui/story/load_story_descriptions.py
@@ -20,15 +20,24 @@ def story_id_to_file(story_id):
     return filepath 
 
 
+def get_story_config(story_id):
+    specific_challenges_file = story_id_to_file(story_id)
+    return read_json(specific_challenges_file)
+
+
 def get_cities(story_id):
     """
     Get the challenges file specificed by the story_id
-    Note: There is no merging with the default story. The story file
-    must fully specify all challenges and cities
     """
-    specific_challenges_file = story_id_to_file(story_id)
+    return get_story_config(story_id)["cities"]
 
-    return read_json(specific_challenges_file)["cities"]
+
+def get_story_settings(story_id):
+    """
+    Return the settings associated with this story config
+    """
+    config = get_story_config(story_id)
+    return config.get("settings", {})
 
 
 def get_challenges_by_id(story_id):

--- a/rlbot_gui/story/story-default-with-cmaps.json
+++ b/rlbot_gui/story/story-default-with-cmaps.json
@@ -1,0 +1,198 @@
+{
+    "bots": { },
+    "cities": {
+        "INTRO": {
+            "description": {
+                "message": "Shoddy field for shoddy players. No boost available.",
+                "prereqs": []
+            },
+            "challenges": [
+                {
+                    "id": "INTRO-1",
+                    "humanTeamSize": 1,
+                    "opponentBots": ["skybot"],
+                    "max_score": "3 Goals",
+                    "map": "BeckwithPark",
+                    "disabledBoost": true,
+                    "display": "Win something so we know you can drive"
+                }
+            ]
+        },
+        "TRYHARD": {
+            "description": {
+                "message": "Place to start making your name! But know that everyone else is trying to do the same!",
+                "prereqs": ["INTRO"],
+                "color": 16
+            },
+            "challenges": [
+                {
+                    "id": "TRYHARD-1",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["nombot", "beast"],
+                    "map": "UrbanCentral",
+                    "display": "Beat local up-and-comers in a 2v2."
+                },
+                {
+                    "id": "TRYHARD-2",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["penguin", "beast"],
+                    "completionConditions": {
+                        "win": true,
+                        "scoreDifference": 3
+                    },
+                    "map": "UrbanCentral_Dawn",
+                    "display": "Upgrade your reputation by beating your opponents by 3 or more goals"
+                }
+            ]
+        },
+        "PBOOST": {
+            "description": {
+                "message": "This city is usually going through a storm. Legend says, Boost is how they have managed to prosper despite those conditions.",
+                "prereqs": ["INTRO"],
+                "color": 32
+            },
+            "challenges": [
+                {
+                    "id": "PBOOST-1",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["cryo", "cryo", "cryo"],
+                    "map": "UtopiaColiseum_Snowy",
+                    "display": "Bundle up to survive the deep freeze"
+                },
+                {
+                    "id": "PBOOST-2",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["rashbot", "stick", "leaf"],
+                    "map": "Mannfield_Stormy",
+                    "display": "2v3! Get through this storm of Marvin bots!"
+                }
+            ]
+        },
+        "WASTELAND": {
+            "description": {
+                "message": "Don't expect politeness here. Home of the demo experts!",
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 36
+            },
+            "challenges": [
+                {
+                    "id": "WASTELAND-1",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["adversity", "adversity"],
+                    "completionConditions": {
+                        "win": true,
+                        "selfDemoCount": 0
+                    },
+                    "map": "Wasteland",
+                    "display": "Win without getting demoed the whole game"
+                },
+                {
+                    "id": "WASTELAND-2",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["adversity", "diablo", "wildfire"],
+                    "completionConditions": {
+                        "win": true,
+                        "demoAchievedCount": 2
+                    },
+                    "map": "Wasteland",
+                    "display": "Win and get at least two demos"
+                }
+            ]
+        },
+        "CAMPANDSNIPE": {
+            "description": {
+                "message": "This city has a different feel. Sometimes the ball is possesed, other times its the cars. Be careful, you may be next!",
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 39
+            },
+            "challenges": [
+            {
+                "id": "CS-1",
+                "humanTeamSize": 2,
+                "opponentBots": ["adversity", "baf"],
+                "limitations": ["half-field"],
+                "map": "AquaDome",
+                "display": "The ball is moving a lot faster! Win this heatseeker match!"
+            },
+            {
+                "id": "CS-2",
+                "humanTeamSize": 1,
+                "opponentBots": ["kamael", "baf"],
+                "limitations": ["half-field"],
+                "completionConditions": {
+                    "goalsScored": 1
+                },
+                "map": "AquaDome",
+                "display": "You are making the saves alone! Win heatseeker 1v2!"
+            },
+            {
+                "id": "CS-4",
+                "humanTeamSize": 2,
+                "opponentBots": ["invisibot", "invisibot", "peter"],
+                "map": "NeoTokyo",
+                "display": "Wait where did that car go?"
+            },
+            {
+                "id": "CS-3",
+                "humanTeamSize": 2,
+                "opponentBots": ["sniper", "sniper", "nombot"],
+                "max_score": "3 Goals",
+                "map": "NeoTokyo",
+                "display": "There's something unnatural about these bots..."
+            },
+            {
+                "id": "CS-5",
+                "humanTeamSize": 1,
+                "opponentBots": ["snek", "peter"],
+                "max_score": "3 Goals",
+                "map": "NeoTokyo",
+                "display": "There's something unnatural-er about these bots"
+            }
+            ]
+        },
+        "CHAMPIONSIAN": {
+            "description": {
+                "message": "You have made it far but this is the next level. The odds are stacked against you but if you win here, you will be the Champion of this world.",
+                "prereqs": ["WASTELAND", "CAMPANDSNIPE"],
+                "color": 69
+            },
+            "challenges": [
+                {
+                    "id": "CHAMP-1",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["airbud", "reliefbot", "adversity"],
+                    "map": "ChampionsField",
+                    "display": "Take on the Relief family in a 3v3!"
+                },
+                {
+                    "id": "CHAMP-2",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["botimus", "sdc", "kamael"],
+                    "map": "ChampionsField_Day",
+                    "display": "Things are getting unfair. Can you handle a 2v3 against some of the best solo players?"
+                },
+                {
+                    "id": "CHAMP-5",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["snek", "sniper", "invisibot"],
+                    "map": "ChampionsField_Day",
+                    "display": "These masters of space and time have united to stop you!"
+                },
+                {
+                    "id": "CHAMP-3",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["kamael", "diablo", "lanfear", "manticore", "atlas"],
+                    "map": "ChampionsField_Day",
+                    "display": "These are mythical and magical cars. Can you take them on in a 3v5?"
+                },
+                {
+                    "id": "CHAMP-4",
+                    "humanTeamSize": 1,
+                    "opponentBots": ["bumblebee", "bumblebee", "bumblebee"],
+                    "map": "ChampionsField",
+                    "display": "1v3! Time to face the beehive."
+                }
+            ]
+        }
+    }
+}

--- a/rlbot_gui/story/story-default-with-cmaps.json
+++ b/rlbot_gui/story/story-default-with-cmaps.json
@@ -1,4 +1,7 @@
 {
+    "settings": {
+        "min_map_pack_revision": 3
+    },
     "bots": { },
     "cities": {
         "INTRO": {

--- a/rlbot_gui/story/story-easy-with-cmaps.json
+++ b/rlbot_gui/story/story-easy-with-cmaps.json
@@ -1,0 +1,187 @@
+{
+    "bots": { },
+    "cities": {
+        "INTRO": {
+            "description": {
+                "message": "Shoddy field for shoddy players. No boost available.",
+                "prereqs": []
+            },
+            "challenges": [
+                {
+                    "id": "INTRO-1",
+                    "humanTeamSize": 1,
+                    "opponentBots": ["skybot"],
+                    "max_score": "3 Goals",
+                    "map": "BeckwithPark",
+                    "disabledBoost": true,
+                    "display": "Win something so we know you can drive"
+                }
+            ]
+        },
+        "TRYHARD": {
+            "description": {
+                "message": "Place to start making your name! But know that everyone else is trying to do the same!",
+                "prereqs": ["INTRO"],
+                "color": 16
+            },
+            "challenges": [
+                {
+                    "id": "TRYHARD-1",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["nombot", "beast"],
+                    "map": "UrbanCentral",
+                    "display": "Beat local up-and-comers in a 2v2."
+                },
+                {
+                    "id": "TRYHARD-2",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["penguin", "beast"],
+                    "completionConditions": {
+                        "win": true,
+                        "scoreDifference": 3
+                    },
+                    "map": "UrbanCentral_Dawn",
+                    "display": "Upgrade your reputation by beating your opponents by 3 or more goals"
+                }
+            ]
+        },
+        "PBOOST": {
+            "description": {
+                "message": "This city is usually going through a storm. Legend says, Boost is how they have managed to prosper despite those conditions.",
+                "prereqs": ["INTRO"],
+                "color": 32
+            },
+            "challenges": [
+                {
+                    "id": "PBOOST-2",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["rashbot", "stick", "leaf"],
+                    "map": "Mannfield_Stormy",
+                    "display": "2v3! Get through this storm of Marvin bots!"
+                },
+                {
+                    "id": "PBOOST-1",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["cryo", "cryo", "cryo"],
+                    "map": "UtopiaColiseum_Snowy",
+                    "display": "Bundle up to survive the deep freeze"
+                }
+            ]
+        },
+        "WASTELAND": {
+            "description": {
+                "message": "Don't expect politeness here. Home of the demo experts!",
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 36
+            },
+            "challenges": [
+                {
+                    "id": "WASTELAND-1",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["adversity", "wildfire"],
+                    "completionConditions": {
+                        "win": true,
+                        "selfDemoCount": 1
+                    },
+                    "map": "Wasteland",
+                    "display": "Win without getting demoed more than once"
+                },
+                {
+                    "id": "WASTELAND-2",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["adversity", "diablo", "wildfire"],
+                    "completionConditions": {
+                        "win": true,
+                        "demoAchievedCount": 2
+                    },
+                    "map": "Wasteland",
+                    "display": "Win and get at least two demos"
+                }
+            ]
+        },
+        "CAMPANDSNIPE": {
+            "description": {
+                "message": "This city has a different feel. Sometimes the ball is possesed, other times its the cars. Be careful, you may be next!",
+                "prereqs": ["TRYHARD", "PBOOST"],
+                "color": 39
+            },
+            "challenges": [
+            {
+                "id": "CS-1",
+                "humanTeamSize": 2,
+                "opponentBots": ["kamael", "baf"],
+                "limitations": ["half-field"],
+                "map": "AquaDome",
+                "display": "The ball is moving a lot faster! Win this heatseeker match!"
+            },
+            {
+                "id": "CS-4",
+                "humanTeamSize": 2,
+                "opponentBots": ["invisibot", "invisibot", "peter"],
+                "map": "NeoTokyo",
+                "display": "Wait where did that car go?"
+            },
+            {
+                "id": "CS-3",
+                "humanTeamSize": 2,
+                "opponentBots": ["sniper", "sniper", "nombot"],
+                "max_score": "3 Goals",
+                "map": "NeoTokyo",
+                "display": "There's something unnatural about these bots..."
+            },
+            {
+                "id": "CS-5",
+                "humanTeamSize": 2,
+                "opponentBots": ["snek", "snek"],
+                "max_score": "3 Goals",
+                "map": "NeoTokyo",
+                "display": "There's something unnatural-er about these bots"
+            }
+            ]
+        },
+        "CHAMPIONSIAN": {
+            "description": {
+                "message": "You have made it far but this is the next level. The odds are stacked against you but if you win here, you will be the Champion of this world.",
+                "prereqs": ["WASTELAND", "CAMPANDSNIPE"],
+                "color": 69
+            },
+            "challenges": [
+                {
+                    "id": "CHAMP-1",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["airbud", "reliefbot", "adversity"],
+                    "map": "ChampionsField",
+                    "display": "Take on the Relief family in a 3v3!"
+                },
+                {
+                    "id": "CHAMP-2",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["botimus", "sdc", "kamael"],
+                    "map": "ChampionsField_Day",
+                    "display": "Take on a crew of some of the best solo players!"
+                },
+                {
+                    "id": "CHAMP-5",
+                    "humanTeamSize": 2,
+                    "opponentBots": ["snek", "sniper", "invisibot"],
+                    "map": "ChampionsField_Day",
+                    "display": "These masters of space and time have united to stop you!"
+                },
+                {
+                    "id": "CHAMP-3",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["diablo", "lanfear", "manticore", "atlas"],
+                    "map": "ChampionsField_Day",
+                    "display": "These are mythical and magical cars. Can you take them on in a 3v4?"
+                },
+                {
+                    "id": "CHAMP-4",
+                    "humanTeamSize": 3,
+                    "opponentBots": ["bumblebee", "bumblebee", "bumblebee"],
+                    "map": "ChampionsField",
+                    "display": "Time to face the beehive and prove yourself."
+                }
+            ]
+        }
+    }
+}

--- a/rlbot_gui/story/story-easy-with-cmaps.json
+++ b/rlbot_gui/story/story-easy-with-cmaps.json
@@ -1,4 +1,7 @@
 {
+    "settings": {
+        "min_map_pack_revision": 3
+    },
     "bots": { },
     "cities": {
         "INTRO": {

--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -40,6 +40,7 @@ RENDERING_GROUP = "STORY"
 DEBUG_MODE_SHORT_GAMES = False
 
 def setup_failure_freeplay(setup_manager: SetupManager, message: str, color_key="red"):
+    setup_manager.shut_down()
     match_config = MatchConfig()
     match_config.game_mode = game_mode_types[0]
     match_config.game_map = "BeckwithPark"
@@ -398,12 +399,12 @@ def manage_game_state(
             results = packet_to_game_results(packet)
 
             if has_user_perma_failed(challenge, stats_tracker.stats):
-                time.sleep(3)
+                time.sleep(1)
                 setup_failure_freeplay(setup_manager, "You failed the challenge!")
                 return early_failure
 
             if end_by_mercy(challenge, stats_tracker.stats, results):
-                time.sleep(5)
+                time.sleep(3)
                 setup_failure_freeplay(setup_manager, "Challenge completed by mercy rule!", "green")
                 return True, results
 

--- a/rlbot_gui/story/story_runner.py
+++ b/rlbot_gui/story/story_runner.py
@@ -13,7 +13,8 @@ from rlbot_gui.story.story_challenge_setup import run_challenge, configure_chall
 from rlbot_gui.story.load_story_descriptions import (
     get_bots_configs,
     get_cities,
-    get_challenges_by_id,
+    get_story_settings,
+    get_challenges_by_id
 )
 
 
@@ -34,6 +35,10 @@ def get_cities_json(story_id):
 @eel.expose
 def get_bots_json(story_id):
     return get_bots_configs(story_id)
+
+@eel.expose
+def get_story_settings_json(story_id):
+    return get_story_settings(story_id)
 
 
 @eel.expose

--- a/rlbot_gui/story/story_runner.py
+++ b/rlbot_gui/story/story_runner.py
@@ -171,10 +171,13 @@ class StoryState:
 
         story_id = story_settings["story_id"]
         custom_config = story_settings["custom_config"]
+        use_custom_maps = story_settings["use_custom_maps"]
         if story_id == 'custom':
             s.story_config = custom_config
         else:
             s.story_config = story_id
+            if use_custom_maps:
+                s.story_config = f"{story_id}-with-cmaps"
         return s
 
     @staticmethod

--- a/rlbot_gui/story/story_runner.py
+++ b/rlbot_gui/story/story_runner.py
@@ -51,9 +51,9 @@ def story_load_save():
 
 
 @eel.expose
-def story_new_save(name, color_secondary, story_id, custom_config):
+def story_new_save(player_settings, story_settings):
     global CURRENT_STATE
-    CURRENT_STATE = StoryState.new(name, color_secondary, story_id, custom_config)
+    CURRENT_STATE = StoryState.new(player_settings, story_settings)
     return story_save_state()
 
 
@@ -162,9 +162,15 @@ class StoryState:
             self.upgrades["currency"] += 2
 
     @staticmethod
-    def new(name, color_secondary, story_id, custom_config):
+    def new(player_settings, story_settings):
         s = StoryState()
+
+        name = player_settings["name"]
+        color_secondary = player_settings["color"]
         s.team_info = {"name": name, "color_secondary": color_secondary}
+
+        story_id = story_settings["story_id"]
+        custom_config = story_settings["custom_config"]
         if story_id == 'custom':
             s.story_config = custom_config
         else:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.101'
+__version__ = '0.0.102'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Currently the user facing option to enable custom maps integration is hidden till we update the config to actually use the maps. Since that will take some investigation to find the right maps and bots combo, I think landing this with the option hidden makes the most sense.

Features:

- User option to start story mode with/without "custom maps" support. The option will result in a different story config JSON file being loaded for the story
- Story Mode will detect if the bot pack/map pack are downloaded. If they are missing, the user will be given a button to download them. This will mean new users don't have to know to download the bot pack. They will get prompted to do it.
  - For map pack, we will also do a version check. The story config can set a "min" version and if the map pack is older than that, then the user will be prompted to update before proceeding with the story.


Minor unrelated changes:

- The "failure" screen wasn't shutting down the previous match so at times there were zombie bots hanging around

## Screenshots

"Use Custom Maps" option:
<img width="300" alt="story-mode-custom-map-1" src="https://user-images.githubusercontent.com/2160795/107138623-8e591600-68e3-11eb-9d13-ba6c1abd17d9.png">

Prompted to download missing packs:
<img width="300" alt="story-mode-custom-map-2" src="https://user-images.githubusercontent.com/2160795/107138622-8e591600-68e3-11eb-850d-ba5a9f9cd886.png">