### PR TITLE
Scripts Integration for Story Mode

### DIFF
--- a/rlbot_gui/story/load_story_descriptions.py
+++ b/rlbot_gui/story/load_story_descriptions.py
@@ -63,3 +63,18 @@ def get_bots_configs(story_id):
         bots.update(read_json(specific_bots_file)["bots"])
 
     return bots
+
+
+def get_scripts_configs(story_id):
+    """
+    Get the scripts in the story config
+    """
+    specific_scripts_file = story_id_to_file(story_id)
+
+    scripts: dict = {}
+    if path.exists(specific_scripts_file):
+        specific_scripts_file_json = read_json(specific_scripts_file)
+        if "scripts" in specific_scripts_file_json:  #  A "scripts" field is optional
+            scripts.update(specific_scripts_file_json["scripts"])
+
+    return scripts

--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -25,7 +25,8 @@ from rlbot.matchconfig.match_config import (
     PlayerConfig,
     MatchConfig,
     MutatorConfig,
-    Team, ScriptConfig,
+    Team,
+    ScriptConfig,
 )
 from rlbot.setup_manager import SetupManager, RocketLeagueLauncherPreference
 
@@ -94,19 +95,23 @@ def make_match_config(
     return match_config
 
 
-def rlbot_to_player_config(player: dict, team: Team):
-    bot_path = player["path"]
-    if isinstance(bot_path, list):
-        bot_path = path.join(*bot_path)
+def collapse_path(cfg_path):
+    if isinstance(cfg_path, list):
+        cfg_path = path.join(*cfg_path)
 
-    if "$RLBOTPACKROOT" in bot_path:
+    if "$RLBOTPACKROOT" in cfg_path:
         for bot_folder in rlbot_gui.bot_folder_settings["folders"].keys():
             adjusted_folder = path.join(bot_folder, "RLBotPack-master")
-            subbed_path = bot_path.replace("$RLBOTPACKROOT", adjusted_folder)
+            subbed_path = cfg_path.replace("$RLBOTPACKROOT", adjusted_folder)
             if path.exists(subbed_path):
-                print("it exists!")
-                bot_path = subbed_path
+                cfg_path = subbed_path
                 break
+
+    return cfg_path
+
+
+def rlbot_to_player_config(player: dict, team: Team):
+    bot_path = collapse_path(player["path"])
 
     player_config = PlayerConfig()
     player_config.bot = True
@@ -120,20 +125,8 @@ def rlbot_to_player_config(player: dict, team: Team):
     return player_config
 
 
-def script_to_script_config(script: dict):
-    script_path = script["path"]
-    if isinstance(script_path, list):
-        script_path = path.join(*script_path)
-
-    if "$RLBOTPACKROOT" in script_path:
-        for bot_folder in rlbot_gui.bot_folder_settings["folders"].keys():
-            adjusted_folder = path.join(bot_folder, "RLBotPack-master")
-            subbed_path = script_path.replace("$RLBOTPACKROOT", adjusted_folder)
-            if path.exists(subbed_path):
-                print("it exists! (script)")
-                script_path = subbed_path
-                break
-
+def script_path_to_script_config(script_path):
+    script_path = collapse_path(script_path)
     return ScriptConfig(script_path)
 
 
@@ -197,7 +190,7 @@ def make_script_configs(
     script_configs = []
 
     for script in challenge.get("scripts", []):
-        script_config = script_to_script_config(all_scripts[script])
+        script_config = script_path_to_script_config(all_scripts[script]["path"])
         script_configs.append(script_config)
 
     return script_configs

--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -25,7 +25,7 @@ from rlbot.matchconfig.match_config import (
     PlayerConfig,
     MatchConfig,
     MutatorConfig,
-    Team,
+    Team, ScriptConfig,
 )
 from rlbot.setup_manager import SetupManager, RocketLeagueLauncherPreference
 
@@ -66,7 +66,7 @@ def setup_failure_freeplay(setup_manager: SetupManager, message: str, color_key=
 
 
 def make_match_config(
-    challenge: dict, upgrades: dict, player_configs: List[PlayerConfig]
+    challenge: dict, upgrades: dict, player_configs: List[PlayerConfig], script_configs: List[ScriptConfig]
 ):
     """Setup the match, following the challenge rules and user's upgrades
     """
@@ -90,6 +90,7 @@ def make_match_config(
         match_config.mutators.rumble = rumble_mutator_types[1]  # All rumble
 
     match_config.player_configs = player_configs
+    match_config.script_configs = script_configs
     return match_config
 
 
@@ -117,6 +118,23 @@ def rlbot_to_player_config(player: dict, team: Team):
     loadout = load_bot_appearance(config.get_looks_config(), team.value)
     player_config.loadout_config = loadout
     return player_config
+
+
+def script_to_script_config(script: dict):
+    script_path = script["path"]
+    if isinstance(script_path, list):
+        script_path = path.join(*script_path)
+
+    if "$RLBOTPACKROOT" in script_path:
+        for bot_folder in rlbot_gui.bot_folder_settings["folders"].keys():
+            adjusted_folder = path.join(bot_folder, "RLBotPack-master")
+            subbed_path = script_path.replace("$RLBOTPACKROOT", adjusted_folder)
+            if path.exists(subbed_path):
+                print("it exists! (script)")
+                script_path = subbed_path
+                break
+
+    return ScriptConfig(script_path)
 
 
 def make_human_config(team: Team):
@@ -171,6 +189,18 @@ def make_player_configs(
         player_configs.append(bot)
 
     return player_configs
+
+
+def make_script_configs(
+    challenge: dict, all_scripts
+):
+    script_configs = []
+
+    for script in challenge.get("scripts", []):
+        script_config = script_to_script_config(all_scripts[script])
+        script_configs.append(script_config)
+
+    return script_configs
 
 
 def packet_to_game_results(game_tick_packet: GameTickPacket):
@@ -471,10 +501,13 @@ def run_challenge(
     return game_results
 
 
-def configure_challenge(challenge: dict, saveState, human_picks: List[int], all_bots):
+def configure_challenge(challenge: dict, saveState, human_picks: List[int], all_bots, all_scripts):
     player_configs = make_player_configs(
         challenge, human_picks, saveState.team_info, saveState.teammates, all_bots
     )
-    match_config = make_match_config(challenge, saveState.upgrades, player_configs)
+    script_configs = make_script_configs(
+        challenge, all_scripts
+    )
+    match_config = make_match_config(challenge, saveState.upgrades, player_configs, script_configs)
 
     return match_config

--- a/rlbot_gui/story/story_runner.py
+++ b/rlbot_gui/story/story_runner.py
@@ -14,7 +14,7 @@ from rlbot_gui.story.load_story_descriptions import (
     get_bots_configs,
     get_cities,
     get_story_settings,
-    get_challenges_by_id
+    get_challenges_by_id, get_scripts_configs
 )
 
 
@@ -199,9 +199,10 @@ def launch_challenge_with_config(challenge_id, pickedTeammates):
     story_id = CURRENT_STATE.story_config
     challenge = get_challenges_by_id(story_id)[challenge_id]
     all_bots = get_bots_configs(story_id)
+    all_scripts = get_scripts_configs(story_id)
 
 
-    match_config = configure_challenge(challenge, CURRENT_STATE, pickedTeammates, all_bots)
+    match_config = configure_challenge(challenge, CURRENT_STATE, pickedTeammates, all_bots, all_scripts)
     launcher_settings_map = load_launcher_settings()
     launcher_prefs = launcher_preferences_from_map(launcher_settings_map)
     completed, results = run_challenge(match_config, challenge, CURRENT_STATE.upgrades, launcher_prefs)

--- a/rlbot_gui/story/story_runner.py
+++ b/rlbot_gui/story/story_runner.py
@@ -14,7 +14,8 @@ from rlbot_gui.story.load_story_descriptions import (
     get_bots_configs,
     get_cities,
     get_story_settings,
-    get_challenges_by_id, get_scripts_configs
+    get_challenges_by_id,
+    get_scripts_configs
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.108'
+__version__ = '0.0.110'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Tested using my own story.json with a script and story-default.json

Currently the "scripts" field is optional in the story json files. Should that be changed?

Also rlbot_to_player_config() and script_to_script_config() share the same first lines but I'm not sure if those lines should be a function instead.