### PR TITLE
Added warning when node isn't installed on Javascript bots.

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -364,9 +364,11 @@ def filter_hidden_bundles(bundles):
 @eel.expose
 def get_language_support():
     java_return_code = os.system("java -version 2> nul")
+    node_return_code = os.system("node --version> nul")
     # Only bother returning iffy languages. No point in sending 'python': True
     return {
         'java': java_return_code == 0,
+        'node': node_return_code == 0,
         'chrome': is_chrome_installed(),  # Scratch bots need chrome to auto-run
         'fullpython': is_full_python(),
     }

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -296,6 +296,15 @@ export default {
 					which makes RLBotGUI better with package management.
 				</p>
 			</div>
+			<div v-if="activeBot.warn === 'node'">
+				<p><b>{{activeBot.name}}</b> requires Node.js to run javascript and it looks like you don't have it installed!</p>
+				To play with it, you'll need to:
+				<ol>
+					<li>Download Node.js from <a href="https://nodejs.org/" target="_blank">nodejs.org</a></li>
+					<li>Install it</li>
+					<li>Restart RLBotGUI</li>
+				</ol>
+			</div>
 		</b-modal>
 
 		<b-modal id="new-bot-modal" title="Create New Bot" hide-footer centered>
@@ -618,11 +627,14 @@ export default {
 				this.botPool.concat(this.scriptPool).forEach((bot) => {
 					if (bot.info && bot.info.language) {
 						const language = bot.info.language.toLowerCase();
-						if (!this.languageSupport.java && language.match(/java|kotlin|scala/)) {
+						if (!this.languageSupport.java && language.match(/java|kotlin|scala/) && !language.match(/javascript/)) {
 							bot.warn = 'java';
 						}
 						if (!this.languageSupport.chrome && language.match(/scratch/)) {
 							bot.warn = 'chrome';
+						}
+						if (!this.languageSupport.node && language.match(/javascript|node|js/)) {
+							bot.warn = 'node';
 						}
 					}
 					if (bot.missing_python_packages && bot.missing_python_packages.length > 0) {

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -633,7 +633,7 @@ export default {
 						if (!this.languageSupport.chrome && language.match(/scratch/)) {
 							bot.warn = 'chrome';
 						}
-						if (!this.languageSupport.node && language.match(/javascript|node|js/)) {
+						if (!this.languageSupport.node && language.match(/(java|type|coffee)script|js|ts|node/)) {
 							bot.warn = 'node';
 						}
 					}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.108'
+__version__ = '0.0.109'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Javascript is now a official language on the rlbot.org website. Users should be warned when trying to play with a Javascript bot and Node.js isn't installed. The warning looks like the other warnings but with different text.
![screenshot](https://i.imgur.com/n4KXhc9.png)
![screenshot](https://i.imgur.com/nhoACei.png)