### PR TITLE
Fix AttributeError on Bot Own-Goal

### DIFF
--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -351,17 +351,16 @@ class ManualStatsTracker:
             if new_score != self._last_score_by_team[team_index]:
                 self._last_score_by_team[team_index] = new_score
 
-                if team_index == self._human_team:
-                    if self._last_touch_by_team[team_index] is not None:
-                        last_touch_player = self._last_touch_by_team[
-                            team_index
-                        ].player_index
-                        last_touch_player_name = self._last_touch_by_team[
-                            team_index
-                        ].player_name
-                        if last_touch_player == self._human_player_index and last_touch_player_name != "":
-                            self.stats["humanGoalsScored"] += 1
-                            print("humanGoalsScored")
+                if team_index == self._human_team and self._last_touch_by_team[team_index] is not None:
+                    last_touch_player = self._last_touch_by_team[
+                        team_index
+                    ].player_index
+                    last_touch_player_name = self._last_touch_by_team[
+                        team_index
+                    ].player_name
+                    if last_touch_player == self._human_player_index and last_touch_player_name != "":
+                        self.stats["humanGoalsScored"] += 1
+                        print("humanGoalsScored")
 
 
 def wait_till_cars_spawned(

--- a/rlbot_gui/story/story_challenge_setup.py
+++ b/rlbot_gui/story/story_challenge_setup.py
@@ -352,12 +352,16 @@ class ManualStatsTracker:
                 self._last_score_by_team[team_index] = new_score
 
                 if team_index == self._human_team:
-                    last_touch_player = self._last_touch_by_team[
-                        team_index
-                    ].player_index
-                    if last_touch_player == self._human_player_index:
-                        self.stats["humanGoalsScored"] += 1
-                        print("humanGoalsScored")
+                    if self._last_touch_by_team[team_index] is not None:
+                        last_touch_player = self._last_touch_by_team[
+                            team_index
+                        ].player_index
+                        last_touch_player_name = self._last_touch_by_team[
+                            team_index
+                        ].player_name
+                        if last_touch_player == self._human_player_index and last_touch_player_name != "":
+                            self.stats["humanGoalsScored"] += 1
+                            print("humanGoalsScored")
 
 
 def wait_till_cars_spawned(

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.110'
+__version__ = '0.0.111'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
If the bot team touches the ball before the packet is grabbed in manage_game_state (so before all the bots load in, so when loading 16 bots for example), the last touch for the player team can be None.

This usually doesn't happen because when the while loop runs before a bot touches the ball, the default last touch has attributes team: 0, player_index: 0, so when the packet is loaded, the player team last touch updates, so it's not None.

Also adds a check for player_name to make sure the player actually touched the ball (player_name is an empty string in the default last touch) for a human goal.

To reproduce, put a time.sleep(10) before the while loop and have a bot own-goal.