### PR TITLE
Fix botpack updating

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.111'
+__version__ = '0.0.112'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Github compression ratio of the botpack is currently 74%, not 65 - so I set it to 75%
The zip file is closer to 60MB than 70MB (it's 54MB)
Return `BotpackStatus.SUCCESS` instead of `True` and `BotpackStatus.REQUIRES_FULL_DOWNLOAD` instead of `False`

This fixes the user continuing to get a prompt that the botpack is out-of-date unless the user does a full download.