### PR TITLE
Some QoL improvements

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -574,9 +574,10 @@ def get_recommendations():
 
 
 @eel.expose
-def show_bot_in_explorer(bot_cfg_path):
+def show_path_in_explorer(path_str):
     import subprocess
-    directory = os.path.dirname(bot_cfg_path)
+    path = Path(path_str)
+    directory = path if path.is_dir() else path.parent
     subprocess.Popen(f'explorer "{directory}"')
 
 

--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -305,6 +305,10 @@ button.icon-button {
   box-shadow: 0 3px 0 green;
 }
 
+.start-match-btn {
+  min-width: 250px;
+}
+
 .navbar-nav {
   align-items: center;
 }

--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -305,6 +305,12 @@ button.icon-button {
   box-shadow: 0 3px 0 green;
 }
 
+.folder-setting-switch {
+  max-width: 1000px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
 .start-match-btn {
   min-width: 250px;
 }

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -197,7 +197,11 @@ export default {
 
 				<span style="flex-grow: 1"></span>
 
-				<b-button @click="startMatch({'blue': blueTeam, 'orange': orangeTeam})" variant="success" size="lg">Start Match</b-button>
+				<b-button @click="startMatch()" variant="success" size="lg" :disabled="matchStarting" class="start-match-btn">
+					<span v-if="matchStarting">Starting match</span>
+					<span v-else-if="gameAlreadyLaunched">Start another match</span>
+					<span v-else>Launch Rocket League<br>and start match</span>
+				</b-button>
 				<b-button @click="killBots()" variant="secondary" size="lg" class="ml-2">Stop</b-button>
 			</div>
 
@@ -460,6 +464,8 @@ export default {
 			showSnackbar: false,
 			snackbarContent: null,
 			showProgressSpinner: false,
+			gameAlreadyLaunched: false,
+			matchStarting: false,
 			languageSupport: null,
 			newBotName: '',
 			newBotLanguageChoice: 'python',
@@ -487,6 +493,8 @@ export default {
 
 	methods: {
 		startMatch: async function (event) {
+			this.matchStarting = true;
+
 			if (this.matchSettings.randomizeMap) await this.setRandomMap();
 
 			this.matchSettings.scripts = this.scriptPool.filter((val) => { return val.enabled });
@@ -818,6 +826,13 @@ export default {
 			eel.expose(noRLBotFlagPopup)
 			function noRLBotFlagPopup(title, text){
 				self.$bvModal.show("no-rlbot-flag-modal")
+				self.matchStarting = false;
+			}
+
+			eel.expose(matchStarted)
+			function matchStarted(){
+				self.matchStarting = false;
+				self.gameAlreadyLaunched = true;
 			}
 
 			eel.expose(updateDownloadProgress);

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -506,6 +506,7 @@ export default {
 		},
 		killBots: function(event) {
 			eel.kill_bots();
+			this.matchStarting = false;
 		},
 		pickBotFolder: function (event) {
 			eel.pick_bot_folder()();

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -624,6 +624,8 @@ export default {
 		passesFilter: function(runnable) {
 			let category = this.secondaryCategorySelected;
 
+			// hide runnable when its name doesn't match the search filter
+			// if the filter is an empty string, anything matches
 			if (!runnable.name.toLowerCase().includes(this.botNameFilter.toLowerCase()))
 				return false;
 			
@@ -631,8 +633,14 @@ export default {
 			if (runnable.type === 'human')
 				return !this.blueTeam.concat(this.orangeTeam).includes(HUMAN);
 
+			// show psyonix bots only in specific categories
 			if (runnable.type === 'psyonix')
 				return category.includePsyonixBots;
+
+			// if a script is enabled, display it regardless of which category is selected
+			// except for the script dependencies, where all scripts are displayed already
+			if (runnable.type === 'script' && !category.displayScriptDependencies && runnable.enabled)
+				return true;
 
 			let allowedTags = runnable.type === 'script' ? category.scripts : category.bots;
 			if (allowedTags) {

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -282,7 +282,7 @@ export default {
 				<b-button v-if="activeBot.type !== 'script'" @click="showAppearanceEditor(activeBot.looks_path)" v-b-modal.appearance-editor-dialog>
 					<b-icon icon="card-image"></b-icon> Edit Appearance
 				</b-button>
-				<b-button v-if="activeBot.path" @click="showBotInExplorer(activeBot.path)">
+				<b-button v-if="activeBot.path" @click="showPathInExplorer(activeBot.path)">
 					<b-icon icon="folder"></b-icon> Show Files
 				</b-button>
 			</div>
@@ -346,26 +346,21 @@ export default {
 		</b-modal>
 
 		<b-modal id="folder-settings-modal" title="Folder Settings" size="xl" hide-footer centered>
-			<b-form inline v-for="(settings, path) in folderSettings.folders">
-				<b-form-checkbox v-model="settings.visible" style="overflow:hidden;">
-					{{ path }}
-				</b-form-checkbox>
+			<span v-for="settingsList in [folderSettings.folders, folderSettings.files]">
+				<b-form inline v-for="(settings, path) in settingsList">
+					<b-form-checkbox switch v-model="settings.visible" class="folder-setting-switch">
+						{{ path }}
+					</b-form-checkbox>
 
-				<b-button size="sm" variant="outline-danger" class="icon-button" @click="Vue.delete(folderSettings.folders, path)">
-					<b-icon icon="x"></b-icon>
-				</b-button>
-			</b-form>
+					<b-button size="sm" class="icon-button" @click="showPathInExplorer(path)" variant="outline-info" v-b-tooltip.hover title="Open folder in explorer">
+						<b-icon icon="folder"></b-icon>
+					</b-button>
 
-			<b-form inline v-for="(settings, path) in folderSettings.files">
-				<b-form-checkbox v-model="settings.visible" style="overflow: hidden;">
-					{{ path }}
-				</b-form-checkbox>
-
-				<b-button size="sm" variant="outline-danger" class="icon-button" @click="Vue.delete(folderSettings.files, path)">
-					<b-icon icon="x"></b-icon>
-				</b-button>
-			</b-form>
-
+					<b-button size="sm" variant="outline-danger" class="icon-button" @click="Vue.delete(settingsList, path)">
+						<b-icon icon="x"></b-icon>
+					</b-button>
+				</b-form>
+			</span>
 			<b-button variant="primary" class="mt-3" @click="applyFolderSettings()">Apply</b-button>
 
 		</b-modal>
@@ -598,8 +593,8 @@ export default {
 			this.activeBot = null;
 			if (path) this.showAppearanceEditor(path);
 		},
-		showBotInExplorer: function (botPath) {
-			eel.show_bot_in_explorer(botPath);
+		showPathInExplorer: function (path) {
+			eel.show_path_in_explorer(path);
 		},
 		hotReload: function() {
 			eel.hot_reload_python_bots();

--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -1,6 +1,7 @@
 from math import pi
 from typing import List
 
+import eel
 from rlbot.gateway_util import NetworkingRole
 from rlbot.matchconfig.loadout_config import LoadoutConfig
 from rlbot.matchconfig.match_config import PlayerConfig, MatchConfig, MutatorConfig, ScriptConfig
@@ -222,6 +223,8 @@ def start_match_helper(bot_list: List[dict], match_settings: dict, launcher_pref
     setup_match(sm , match_config, launcher_prefs)
     # Note that we are not calling infinite_loop because that is not compatible with the way eel works!
     # Instead we will reproduce the important behavior from infinite_loop inside this file.
+
+    eel.matchStarted()
 
 
 def do_infinite_loop_content():

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.116'
+__version__ = '0.0.117'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
- Enabled scripts are now visible regardless of which tab is selected. Resolves #162

- The start match button now has 3 states:
  - Launch Rocket League and start match
  - Starting match (button is disabled)
  - Start another match
  
  This is to hopefully better communicate that RLBot also launches Rocket League but only needs to do that once. Making the button disabled while starting the match prevents people from accidentally clicking it multiple times, and also gives some visual feedback that the app is doing _something_ when the button is clicked.

- Folder settings now have handy buttons to open the folder in explorer. Also refactored a bit.
  