### PR TITLE
Add flag when installing from packages pip to the GUI's Python

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -418,7 +418,7 @@ def get_match_options():
 
 @eel.expose
 def install_package(package_string):
-    exit_code = subprocess.call([sys.executable, "-m", "pip", "install", '--upgrade', package_string])
+    exit_code = subprocess.call([sys.executable, "-m", "pip", "install", '--upgrade', '--no-warn-script-location', package_string])
     print(exit_code)
     return {'exitCode': exit_code, 'package': package_string}
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.117'
+__version__ = '0.0.118'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
This will do nothing until the latest version of the installer is published and downloaded.

Adding the flag `--no-warn-script-location` stops Python from warning that Python isn't on the user's PATH, and we know and want that. This change is so no users get scared from the warning.