### PR TITLE
Making the GUI always use epic login tricks

### DIFF
--- a/rlbot_gui/gui/js/launcher-preference-vue.js
+++ b/rlbot_gui/gui/js/launcher-preference-vue.js
@@ -7,15 +7,6 @@ export default {
 			<b-form-group>
 				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="steam">Steam</b-form-radio>
 				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="epic">Epic Games</b-form-radio>
-				<b-form-checkbox
-					class="ml-4"
-					v-model="launcherSettings.use_login_tricks" 
-					:disabled="launcherSettings.preferred_launcher !== 'epic'">
-				
-					Get My Items/Settings <b-icon class="warning-icon" icon="exclamation-triangle-fill" v-b-tooltip.hover 
-					title="If you choose this, we'll do some fancy things to make sure your Epic account logs in successfully and loads your car + camera settings. 
-					It might look slightly weird on the Epic login server but they probably won't care."></b-icon>
-				</b-form-checkbox>
 			</b-form-group>
 		</div>
 		<b-button variant="primary" class="mt-3" @click="saveLauncherSettings()">Save</b-button>
@@ -23,7 +14,7 @@ export default {
 	`,
 	data () {
 		return {
-			launcherSettings: { preferred_launcher: 'epic', use_login_tricks: false },
+			launcherSettings: { preferred_launcher: 'epic', use_login_tricks: true },
 		}
 	},
 
@@ -40,12 +31,5 @@ export default {
 	},
 	created: function () {
 		eel.get_launcher_settings()(this.launcherSettingsReceived);
-	},
-	watch: {
-		'launcherSettings.preferred_launcher': function(newVal) {
-			if (newVal === 'steam') {
-				this.launcherSettings.use_login_tricks = false;
-			}
-		}
 	},
 }

--- a/rlbot_gui/persistence/settings.py
+++ b/rlbot_gui/persistence/settings.py
@@ -12,8 +12,9 @@ def load_settings() -> QSettings:
 
 
 def launcher_preferences_from_map(launcher_preference_map: dict) -> RocketLeagueLauncherPreference:
-    return RocketLeagueLauncherPreference(launcher_preference_map['preferred_launcher'],
-                                          launcher_preference_map['use_login_tricks'])
+    return RocketLeagueLauncherPreference(
+        launcher_preference_map['preferred_launcher'],
+        use_login_tricks=True)  # Epic launch now ONLY works with login tricks
 
 
 def load_launcher_settings():

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.118'
+__version__ = '0.0.119'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
With the season 4 update, we are now unable to launch Rocket League with the necessary arguments unless we use the "epic login tricks" technique. This used to be opt-in because we were originally not 100% sure it was safe for our users. We've been offering it for a very long time now with no reports of problems, so I consider it to be safe, and it's also the better experience.

I'm removing the choice, and all epic users will go through the login tricks path.

See investigation here: https://discordapp.com/channels/348658686962696195/348659150793736193/876549683466633256