### PR TITLE
Add link to languages list in Create Bot dialog

### DIFF
--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -341,6 +341,7 @@ export default {
 					<b-form-radio v-model="newBotLanguageChoice" name="lang-radios" value="scratch">Scratch</b-form-radio>
 				</b-form-group>
 			</div>
+			<p style="margin-top: -1rem">If your language isn't listed here, try <a href="https://github.com/RLBot/RLBot/wiki/Supported-Programming-Languages" target="_blank">this list</a>.</p>
 
 			<b-button variant="primary" @click="beginNewBot(newBotLanguageChoice, newBotName)">Begin</b-button>
 		</b-modal>


### PR DESCRIPTION
![preview](https://user-images.githubusercontent.com/1981364/135731806-357ca902-77a2-4868-89dc-9b7f6506b641.png)

the weird little CSS rule is because otherwise there's a gap between the radio button group and the new text, and it looks bad