### PR TITLE
Randomize buttons in appearance editor

### DIFF
--- a/rlbot_gui/gui/csv/items.csv
+++ b/rlbot_gui/gui/csv/items.csv
@@ -3165,7 +3165,7 @@
 5220,Skin,Product_TA ProductsDB.Products.skin_lemonade_namesake,Harbinger: Namesake
 5221,Skin,Product_TA ProductsDB.Products.skin_lemonade_stripes,Harbinger: Stripes
 5222,Skin,Product_TA ProductsDB.Products.skin_sr_ziggystarfish_t1,S3 - Bronze
-5223,Skin,Product_TA ProductsDB.Products.skin_sr_ziggystarfish_t2,S3- Silver
+5223,Skin,Product_TA ProductsDB.Products.skin_sr_ziggystarfish_t2,S3 - Silver
 5224,Skin,Product_TA ProductsDB.Products.skin_sr_ziggystarfish_t3,S3 - Gold
 5225,Skin,Product_TA ProductsDB.Products.skin_sr_ziggystarfish_t4,S3 - Platinum
 5226,Skin,Product_TA ProductsDB.Products.skin_sr_ziggystarfish_t5,S3 - Diamond
@@ -3549,6 +3549,7 @@
 5810,Skin,Product_TA ProductsDB.Products.skin_brick_Misterrad,Tygris: Mister Rad
 5811,Skin,Product_TA ProductsDB.Products.skin_brick_nineK,Tygris: Full Speed
 5812,Skin,Product_TA ProductsDB.Products.skin_brick_stripes,Tygris: Stripes
+5813,Hat,Product_TA ProductsDB.Products.hat_football,NFL
 5814,Skin,Product_TA ProductsDB.Products.skin_grain_feralcat,Fennec: Bodacious
 5815,Skin,Product_TA ProductsDB.Products.skin_brick_BigDidge,Tygris: Platformer
 5816,Skin,Product_TA ProductsDB.Products.skin_brick_simplefade,Tygris: Silencer
@@ -3556,6 +3557,7 @@
 5819,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_xgames_01,X-Skis
 5820,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_xgames_02,X-Board
 5821,Skin,Product_TA ProductsDB.Products.Skin_octane_Dueling,Octane: 10dril
+5822,Boost,Product_TA ProductsDB.Products.boost_almond,NFL
 5823,Body,Product_TA ProductsDB.Products.body_oramac,NASCAR Chevrolet Camaro
 5824,Boost,Product_TA ProductsDB.Products.boost_checkeredflag,Chequered Flag
 5826,GoalExplosion,Product_TA ProductsDB.Products.explosion_singleatom,Atomic Blip
@@ -3680,6 +3682,7 @@
 6010,Wheels,Product_TA ProductsDB.Products.wheel_nct,Goodyear Racing
 6011,Hat,Product_TA ProductsDB.Products.hat_th,Formal Fitter
 6012,Skin,Product_TA ProductsDB.Products.skin_dekkar,Heat Lighting
+6013,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_nct,NASCAR
 6014,Skin,Product_TA ProductsDB.Products.skin_fracture_Alf,Formula 1 2021: Alfa Romeo 2021
 6015,SupersonicTrail,Product_TA ProductsDB.Products.ss_nct,NASCAR
 6018,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_fracture,Formula 1 2021
@@ -3772,6 +3775,7 @@
 6152,MusicStingers,Product_TA ProductsDB.Products.Anthem_Anitta_Furiosa,Furiosa
 6153,MusicStingers,Product_TA ProductsDB.Products.Anthem_TeriyakiBoyz_TokyoDrift,Tokyo Drift
 6154,MusicStingers,Product_TA ProductsDB.Products.Album_Anthem_FF,Fast & Furious
+6155,MusicStingers,Product_TA ProductsDB.Products.Anthem_RadioClassics_Vol1_01,All Star
 6156,MusicStingers,Product_TA ProductsDB.Products.Album_Anthem_RadioClassics_Vol1,Radio Classics Vol. 1
 6157,Skin,Product_TA ProductsDB.Products.skin_drofd,Ford F-150 RLE: Formation BFT
 6158,MusicStingers,Product_TA ProductsDB.Products.Anthem_HoaproxAndYUAN_Saviour_featHaneri,Saviour (feat. Haneri)
@@ -3831,4 +3835,46 @@
 6240,EngineAudio,Product_TA ProductsDB.Products.engineaudio_chopper,Steel Horse
 6252,MusicStingers,Product_TA ProductsDB.Products.Anthem_2ts_Vol1_ID_04,H O L D O N
 6254,MusicStingers,Product_TA ProductsDB.Products.Album_Anthem_2ts_Vol1,D R I F T
+6261,Wheels,Product_TA ProductsDB.Products.wheel_flowerboom,Acero-Florentina
+6287,Skin,Product_TA ProductsDB.Products.skin_musclecar_gb,Dominus: Green Bay Packers
+6313,Skin,Product_TA ProductsDB.Products.skin_musclecar_arz_h,Dominus: Arizona Cardinals
+6381,Skin,Product_TA ProductsDB.Products.skin_musclecar_atl_h,Dominus: Atlanta Falcons
+6382,Skin,Product_TA ProductsDB.Products.skin_musclecar_btl_h,Dominus: Baltimore Ravens
+6383,Skin,Product_TA ProductsDB.Products.skin_musclecar_buf_h,Dominus: Buffalo Bills
+6384,Skin,Product_TA ProductsDB.Products.skin_musclecar_car_h,Dominus: Carolina Panthers
+6385,Skin,Product_TA ProductsDB.Products.skin_musclecar_chi_h,Dominus: Chicago Bears
+6386,Skin,Product_TA ProductsDB.Products.skin_musclecar_cin_h,Dominus: Cincinnati Bengals
+6387,Skin,Product_TA ProductsDB.Products.skin_musclecar_cle_h,Dominus: Cleveland Browns
+6388,Skin,Product_TA ProductsDB.Products.skin_musclecar_dal_h,Dominus: Dallas Cowboys
+6389,Skin,Product_TA ProductsDB.Products.skin_musclecar_den_h,Dominus: Denver Broncos
+6390,Skin,Product_TA ProductsDB.Products.skin_musclecar_det_h,Dominus: Detroit Lions
+6391,Skin,Product_TA ProductsDB.Products.skin_musclecar_hou_h,Dominus: Houston Texans
+6392,Skin,Product_TA ProductsDB.Products.skin_musclecar_ind_h,Dominus: Indianapolis Colts
+6393,Skin,Product_TA ProductsDB.Products.skin_musclecar_jax_h,Dominus: Jacksonville Jaguars
+6394,Skin,Product_TA ProductsDB.Products.skin_musclecar_kc_h,Dominus: Kansas City Chiefs
+6395,Skin,Product_TA ProductsDB.Products.skin_musclecar_lac_h,Dominus: Los Angeles Chargers
+6396,Skin,Product_TA ProductsDB.Products.skin_musclecar_lar_h,Dominus: Los Angeles Rams
+6397,Skin,Product_TA ProductsDB.Products.skin_musclecar_las_h,Dominus: Las Vegas Raiders
+6398,Skin,Product_TA ProductsDB.Products.skin_musclecar_mia_h,Dominus: Miami Dolphins
+6399,Skin,Product_TA ProductsDB.Products.skin_musclecar_min_h,Dominus: Minnesota Vikings
+6400,Skin,Product_TA ProductsDB.Products.skin_musclecar_ne_h,Dominus: New England Patriots
+6401,Skin,Product_TA ProductsDB.Products.skin_musclecar_no_h,Dominus: New Orleans Saints
+6402,Skin,Product_TA ProductsDB.Products.skin_musclecar_nyg_h,Dominus: New York Giants
+6403,Skin,Product_TA ProductsDB.Products.skin_musclecar_nyj_h,Dominus: New York Jets
+6404,Skin,Product_TA ProductsDB.Products.skin_musclecar_phi_h,Dominus: Philadelphia Eagles
+6405,Skin,Product_TA ProductsDB.Products.skin_musclecar_pit_h,Dominus: Pittsburgh Steelers
+6406,Skin,Product_TA ProductsDB.Products.skin_musclecar_sea_h,Dominus: Seattle Seahawks
+6407,Skin,Product_TA ProductsDB.Products.skin_musclecar_sf_h,Dominus: San Francisco 49ers
+6408,Skin,Product_TA ProductsDB.Products.skin_musclecar_tb_h,Dominus: Tampa Bay Buccaneers
+6409,Skin,Product_TA ProductsDB.Products.skin_musclecar_ten_h,Dominus: Tennessee Titans
+6410,Skin,Product_TA ProductsDB.Products.skin_musclecar_was_h,Dominus: Washington Football Team
+6487,PaintFinish,Product_TA ProductsDB.Products.paintfinish_football,Pigskin
 6488,MusicStingers,Product_TA ProductsDB.Products.Anthem_SMLE_Athena_Eternal,Eternal
+6591,MusicStingers,Product_TA ProductsDB.Products.Anthem_AL3JANDRO_Loca,Loca
+6594,MusicStingers,Product_TA ProductsDB.Products.Anthem_AL3JANDRO_SoGood,So Good
+6595,MusicStingers,Product_TA ProductsDB.Products.Anthem_AL3JANDRO_WeOwnTheNight,We Own The Night
+6596,MusicStingers,Product_TA ProductsDB.Products.Album_Anthem_AL3JANDRO_HHM2021,HHM 2021
+6597,MusicStingers,Product_TA ProductsDB.Products.Anthem_Stonebank_KeepUpThePace,Keep Up The Pace
+6694,Antenna,Product_TA ProductsDB.Products.flag_mc_oblvyn,OBLVYN
+6695,Antenna,Product_TA ProductsDB.Products.flag_mc_caster,Caster
+6696,Antenna,Product_TA ProductsDB.Products.flag_mc_sabai,Sabai

--- a/rlbot_gui/gui/js/appearance-editor-vue.js
+++ b/rlbot_gui/gui/js/appearance-editor-vue.js
@@ -28,13 +28,16 @@ export default {
 			<b-col v-for="team in teams">
 				<colorpicker text="Primary Color" v-model="config[team]['team_color_id']" primary :team="team"/>
 				<colorpicker text="Accent Color" v-model="config[team]['custom_color_id']"/>
+				<b-button class="float-right" @click="randomizeTeamLoadout(team)" v-b-tooltip.hover :title="'Randomize entire ' + team + ' team loadout'">
+					<b-icon icon="shuffle"/>
+				</b-button>
 			</b-col>
 		</b-row>
 
 		<b-row v-if="Object.keys(config.blue).length" class="mb-4">
 			<b-col v-for="team in teams">
 				<div v-for="itemType in itemTypes">
-					<item-field :item-type="itemType" :items="items[itemType.category]" :team="team" v-model="config[team]"/>
+					<item-field :item-type="itemType" :items="items[itemType.category]" :team="team" v-model="config[team]" :ref="team"/>
 				</div>
 			</b-col>
 		</b-row>
@@ -45,19 +48,24 @@ export default {
 					<b-icon icon="eye"></b-icon>
 					View blue car in game
 				</b-button>
+
 				<b-button variant="outline-primary" @click="spawnCarForViewing(1)" class="mr-1">
 					<b-icon icon="eye"></b-icon>
 					View orange car in game
 				</b-button>
+
 				<b-form-select v-model="selectedShowcaseType">
 					<b-form-select-option v-for="showcaseType in showcaseTypes" :value="showcaseType.id">
 						{{ showcaseType.name }}
 					</b-form-select-option>
 				</b-form-select>
+
 				<span style="flex-grow: 1"></span>
+
 				<b-button variant="primary" @click="saveAppearance" class="mr-1">
 					Save and close
 				</b-button>
+
 				<b-button @click="loadLooks(path)">
 					Revert changes
 				</b-button>
@@ -80,8 +88,8 @@ export default {
 					{name: 'Boost', category: 'Boost', itemKey: 'boost_id', paintKey: 'boost_paint_id'},
 					{name: 'Antenna', category: 'Antenna', itemKey: 'antenna_id', paintKey: 'antenna_paint_id'},
 					{name: 'Topper', category: 'Hat', itemKey: 'hat_id', paintKey: 'hat_paint_id'},
-					{name: 'Paint Finish', category: 'PaintFinish', itemKey: 'paint_finish_id', paintKey: null},
-					{name: 'Accent Paint Finish', category: 'PaintFinish', itemKey: 'custom_finish_id', paintKey: null},
+					{name: 'Primary Finish', category: 'PaintFinish', itemKey: 'paint_finish_id', paintKey: null},
+					{name: 'Accent Finish', category: 'PaintFinish', itemKey: 'custom_finish_id', paintKey: null},
 					{name: 'Engine Audio', category: 'EngineAudio', itemKey: 'engine_audio_id', paintKey: null},
 					{name: 'Trail', category: 'SupersonicTrail', itemKey: 'trails_id', paintKey: 'trails_paint_id'},
 					{name: 'Goal Explosion', category: 'GoalExplosion', itemKey: 'goal_explosion_id', paintKey: 'goal_explosion_paint_id'},
@@ -142,7 +150,16 @@ export default {
 			},
 			loadLooks: async function (path) {
 				this.config = await eel.get_looks(path)();
-			}
+			},
+			randomizeTeamLoadout: function(team) {
+				this.config[team].team_color_id = Math.round(Math.random() * 70);
+				this.config[team].custom_color_id = Math.round(Math.random() * 105);
+
+				for (const itemField of this.$refs[team]) {
+					itemField.selectRandomItem();
+					itemField.selectRandomPaintColor();
+				}
+			},
 		},
 
 	created: function() {

--- a/rlbot_gui/gui/js/item-field-vue.js
+++ b/rlbot_gui/gui/js/item-field-vue.js
@@ -18,6 +18,7 @@ export default {
 						:list="'list' + itemType.name + team"
 						autocomplete="off"
 						:state="validationState"
+						@mousedown="itemSelection = '';"
 					/>
 					<b-form-datalist :id="'list' + itemType.name + team" :options="items" value-field="itemKey" text-field="name"></b-form-datalist>
 

--- a/rlbot_gui/gui/js/item-field-vue.js
+++ b/rlbot_gui/gui/js/item-field-vue.js
@@ -3,12 +3,28 @@ export default {
 	props: ['value', 'items', 'itemType', 'team'],
 	template: `
 	<b-row>
-		<b-col>
-			<b-form-group :label="itemType.name" label-cols="5">
-				<b-form-input v-model="itemSelection" :list="'list' + itemType.name + team" autocomplete="off" :state="validationState"></b-form-input>
-				<b-form-datalist :id="'list' + itemType.name + team" :options="items" value-field="itemKey" text-field="name"></b-form-datalist>
+		<b-col class="pr-1">
+			<b-form-group :label="itemType.name" label-cols="4">
+				<b-input-group>
+						
+					<b-input-group-prepend>
+						<b-button variant="secondary" size="sm" v-b-tooltip.hover title="Set random" @click="selectRandomItem">
+							<b-icon icon="shuffle"/>
+						</b-button>
+					</b-input-group-prepend>
+
+					<b-form-input
+						v-model="itemSelection"
+						:list="'list' + itemType.name + team"
+						autocomplete="off"
+						:state="validationState"
+					/>
+					<b-form-datalist :id="'list' + itemType.name + team" :options="items" value-field="itemKey" text-field="name"></b-form-datalist>
+
+				</b-input-group>
 			</b-form-group>
 		</b-col>
+
 		<b-col cols="3">
 			<md-field v-if="itemType.paintKey">
 				<b-form-select v-model="selectedPaint" class="paint-color" :class="selectedPaintColorClass">
@@ -47,6 +63,14 @@ export default {
 			let id = this.value[this.itemType.itemKey];
 			let item = this.items.find(el => el.id === id);
 			this.itemSelection = item ? item.name : '';
+		},
+		selectRandomItem: function() {
+			let randomIndex = Math.floor(Math.random() * this.items.length);
+			this.itemSelection = this.items[randomIndex].name;
+		},
+		selectRandomPaintColor: function() {
+			let randomIndex = Math.floor(Math.random() * this.paintColors.length);
+			this.selectedPaint = this.paintColors[randomIndex].id;
 		},
 	},
 	created: function() {

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.120'
+__version__ = '0.0.121'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
- buttons to randomize items and entire team loadouts
  ![5fc8e896a7557584575b5e4464489545](https://user-images.githubusercontent.com/18472149/135929368-63d4a7b5-4527-4c68-9885-26f33e97cd2b.gif)
- added latest items
- when clicking the text input of an item, it now gets cleared, so that the entire datalist appears. This is because some users were confused when they clicked an item, for example _Octane_, and only _Octane_ and _Octane ZSR_ showed up. Also it saves you a keyboard press :)