### PR TITLE
Remove old NumPy version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     install_requires=[
         'numba==0.48.0',
         'scipy',
-        'numpy==1.19.3',
+        'numpy',
         'RLUtilities',  # Used by Snek
         'websockets',  # Needed for scratch bots
         'selenium',  # Needed for scratch bots

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.128'
+__version__ = '0.0.129'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
This was a fix to an old issue that NumPy had, it's safe to remove this now and get all of the bug fixes and improvements that come with the newest version. We're currently on version 1.22 and 1.19 is becoming old.