### PR TITLE
Linux botpack upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.129'
+__version__ = '0.0.130'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Botpack incremental zips are made in Windows via Powershell.

Powershell and Windows are weird and this results in the files being extracted to the root folder with a name like `RLBotPack\Necto\bot.cfg` instead of being in their proper folders.

This PR just adds an if statement that checks for a non-Windows system and then loops through all the files, renaming them. Works on Linux, at the very least.

ALSO, the script now deletes the `.deleted` file when it's done so it's not lingering around after the upgrade.