### PR TITLE
Fix opening a file explorer, cross-platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pip
 gevent
 eel>=0.12
 PyQt5
+show-in-file-manager

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -39,6 +39,8 @@ from rlbot import gateway_util
 from rlbot_gui.story import story_runner
 ####
 
+from showinfm import show_in_file_manager
+
 DEFAULT_BOT_FOLDER = 'default_bot_folder'
 BOTPACK_FOLDER = 'RLBotPackDeletable'
 MAPPACK_FOLDER = 'RLBotMapPackDeletable'
@@ -581,10 +583,9 @@ def get_recommendations():
 
 @eel.expose
 def show_path_in_explorer(path_str):
-    import subprocess
     path = Path(path_str)
     directory = path if path.is_dir() else path.parent
-    subprocess.Popen(f'explorer "{directory}"')
+    show_in_file_manager(str(directory))
 
 
 @eel.expose

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.129'
+__version__ = '0.0.131'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Please pull #181 first, so the version update number goes in order

This should fix launching a file explorer in several different OSs.

Check out the package's readme for a list. It only needs to be listed to work. https://pypi.org/project/show-in-file-manager/