### PR TITLE
Fix possible error when item is folder

### DIFF
--- a/rlbot_gui/bot_management/downloader.py
+++ b/rlbot_gui/bot_management/downloader.py
@@ -261,6 +261,12 @@ class BotpackUpdater:
                                 old_path = local_folder_path / zipinfo
                                 new_path = local_folder_path / zipinfo.replace("\\", "/")
 
+                                if zipinfo[-1] == "\\":
+                                    if not os.path.exists(new_path):
+                                        os.makedirs(new_path)
+                                    os.remove(old_path)
+                                    continue
+
                                 if not os.path.isdir(new_path.parent):
                                     os.makedirs(new_path.parent)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.132'
+__version__ = '0.0.133'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
When the item is a folder and not a file, either a file will be created with the same name or, if the folder already exists, an error will be thrown by `os.rename`. This change fixes that.