### PR TITLE
Python 3.9 Compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.132'
+__version__ = '0.0.133'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()
@@ -12,13 +12,12 @@ setuptools.setup(
     # already bundling those in the pynsist installer.
     # We'll go ahead and list some packages needed by bots in the bot pack, though.
     install_requires=[
-        'numba==0.48.0',
+        'numba~=0.55.0',
         'scipy',
         'numpy',
-        'RLUtilities',  # Used by Snek
         'websockets',  # Needed for scratch bots
         'selenium',  # Needed for scratch bots
-        'PyQt5==5.15.0'  # Used for settings and file pickers currently.
+        'PyQt5~=5.15.1'  # Used for settings and file pickers currently.
         ],
     version=__version__,
     description='A streamlined user interface for RLBot.',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.133'
+__version__ = '0.0.134'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Simply upping the pinned versions (to numba 0.55, at least bug fix patch 0 and pyqt5, at least debug fix patch 1) is all that's needed for RLBot to at least run on Python 3.9. (Python 3.7 still works, of course.)

Apart of RLBot/RLBot#583