### PR TITLE
Adding a launcher option for epic only, fixing mime type issue.

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 import platform
 import shutil
@@ -743,6 +744,8 @@ def init_settings():
 
 def start():
     init_settings()
+    # Some people get defaulted to text/plain for some reason, and Chrome forbids that.
+    mimetypes.add_type('text/javascript', '.js')
     gui_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'gui')
     eel.init(gui_folder)
 

--- a/rlbot_gui/gui/js/launcher-preference-vue.js
+++ b/rlbot_gui/gui/js/launcher-preference-vue.js
@@ -9,6 +9,16 @@ export default {
 				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="steam">Steam</b-form-radio>
 				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="epic_only">Epic Games</b-form-radio>
 			</b-form-group>
+			<b-form-group 
+				label="Optional: Path to RocketLeague.exe for Epic Launcher" 
+				description="Only needed if it's not working automatically, only used by Epic launcher.">
+				<b-form-input
+					v-model="launcherSettings.rocket_league_exe_path"
+					trim
+					placeholder="C:\\Path\\To\\Your\\RocketLeague.exe"
+					:disabled="launcherSettings.preferred_launcher == 'steam'">
+				</b-form-input>
+			</b-form-group>
 		</div>
 		<b-button variant="primary" class="mt-3" @click="saveLauncherSettings()">Save</b-button>
 	</div>

--- a/rlbot_gui/gui/js/launcher-preference-vue.js
+++ b/rlbot_gui/gui/js/launcher-preference-vue.js
@@ -5,8 +5,9 @@ export default {
 	<div>
 		<div>
 			<b-form-group>
+				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="epic">Try All</b-form-radio>
 				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="steam">Steam</b-form-radio>
-				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="epic">Epic Games</b-form-radio>
+				<b-form-radio v-model="launcherSettings.preferred_launcher" name="launcher-radios" value="epic_only">Epic Games</b-form-radio>
 			</b-form-group>
 		</div>
 		<b-button variant="primary" class="mt-3" @click="saveLauncherSettings()">Save</b-button>

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -528,7 +528,7 @@ export default {
 		},
 		downloadBotPack: function() {
 			this.showBotpackUpdateSnackbar = false;
-			this.downloadModalTitle = "Downloading Bot Pack" 
+			this.downloadModalTitle = "Downloading Bot Pack"
 			this.$bvModal.show('download-modal');
 			this.downloadStatus = "Starting";
 			this.downloadProgressPercent = 0;
@@ -536,7 +536,7 @@ export default {
 		},
 		updateBotPack: function() {
 			this.showBotpackUpdateSnackbar = false;
-			this.downloadModalTitle = "Updating Bot Pack" 
+			this.downloadModalTitle = "Updating Bot Pack"
 			this.$bvModal.show('download-modal');
 			this.downloadStatus = "Starting";
 			this.downloadProgressPercent = 0;
@@ -544,7 +544,7 @@ export default {
 		},
 		updateMapPack: function() {
 			this.showBotpackUpdateSnackbar = false;
-			this.downloadModalTitle = "Downloading Custom Maps" 
+			this.downloadModalTitle = "Downloading Custom Maps"
 			this.$bvModal.show('download-modal');
 			this.downloadStatus = "Starting";
 			this.downloadProgressPercent = 0;
@@ -768,6 +768,13 @@ export default {
 			function matchStarted(){
 				self.matchStarting = false;
 				self.gameAlreadyLaunched = true;
+			}
+
+			eel.expose(matchStartFailed)
+			function matchStartFailed(message){
+				self.matchStarting = false;
+				self.snackbarContent = "Error starting match: " + message + "\n See console for more details.";
+				self.showSnackbar = true;
 			}
 
 			eel.expose(updateDownloadProgress);

--- a/rlbot_gui/match_runner/match_runner.py
+++ b/rlbot_gui/match_runner/match_runner.py
@@ -220,10 +220,15 @@ def start_match_helper(bot_list: List[dict], match_settings: dict, launcher_pref
     match_config.script_configs = [create_script_config(script) for script in match_settings['scripts']]
 
     sm = get_fresh_setup_manager()
-    setup_match(sm , match_config, launcher_prefs)
+    try:
+        setup_match(sm, match_config, launcher_prefs)
+    except Exception as e:
+        print(e)
+        eel.matchStartFailed(str(e))
+        return
+
     # Note that we are not calling infinite_loop because that is not compatible with the way eel works!
     # Instead we will reproduce the important behavior from infinite_loop inside this file.
-
     eel.matchStarted()
 
 

--- a/rlbot_gui/persistence/settings.py
+++ b/rlbot_gui/persistence/settings.py
@@ -12,9 +12,15 @@ def load_settings() -> QSettings:
 
 
 def launcher_preferences_from_map(launcher_preference_map: dict) -> RocketLeagueLauncherPreference:
+    exe_path = launcher_preference_map['rocket_league_exe_path']
+    if not exe_path:
+        exe_path = None  # Don't pass in an empty string, pass None instead so it will be ignored.
+
     return RocketLeagueLauncherPreference(
         launcher_preference_map['preferred_launcher'],
-        use_login_tricks=True)  # Epic launch now ONLY works with login tricks
+        use_login_tricks=True,  # Epic launch now ONLY works with login tricks
+        rocket_league_exe_path=exe_path,
+    )
 
 
 def load_launcher_settings():

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.133'
+__version__ = '0.0.134'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
When people choose epic games, it will not fall back to steam anymore. The default is still the previous behavior, which is now labeled "Try All".

![image](https://user-images.githubusercontent.com/575644/167274528-11797d3b-a058-48f4-8fb7-9f16877bfcab.png)

Also had an issue loading RLBotGUI on my system, turns out python's mimetypes lib was assigning text/plain to .js files for some reason. This should fix it for anyone else experiencing the same. This person maybe? https://discordapp.com/channels/348658686962696195/348659150793736193/972629607796842586
