### PR TITLE
Maintenance

### DIFF
--- a/rlbot_gui/gui/csv/items.csv
+++ b/rlbot_gui/gui/csv/items.csv
@@ -1925,6 +1925,7 @@
 3160,Wheels,Product_TA ProductsDB.Products.wheel_betray_tier3,Capacitor III
 3161,Wheels,Product_TA ProductsDB.Products.wheel_betray_tier4,Capacitor IV
 3167,PlayerBanner,Product_TA ProductsDB.Products.PlayerBanner_InkWarrior,Ink Wash
+3170,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_roses,Rosie
 3171,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_tigerandphoenix,Hot Ice
 3176,PlayerAvatarBorder,Product_TA ProductsDB.Products.avatarborder_flames,Flame
 3177,PlayerAvatarBorder,Product_TA ProductsDB.Products.AvatarBorder_OctaneTech,Free Ride
@@ -2986,6 +2987,7 @@
 4779,Wheels,Product_TA ProductsDB.Products.wheel_energyring,Jandertek
 4780,Body,Product_TA ProductsDB.Products.body_bb,Battle Bus
 4781,Body,Product_TA ProductsDB.Products.body_shark,Peregrine TT
+4782,Body,Product_TA ProductsDB.Products.body_tritip,Psyclops
 4783,Boost,Product_TA ProductsDB.Products.boost_geotech,HoloData
 4784,GoalExplosion,Product_TA ProductsDB.Products.Explosion_Baseballs,Grand Slam
 4785,SupersonicTrail,Product_TA ProductsDB.Products.ss_geotech,HoloData
@@ -3097,6 +3099,7 @@
 4955,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_abstract_one,Wet Wash
 4957,Skin,Product_TA ProductsDB.Products.skin_mitty_line,Komodo: Takeover
 4958,PlayerBanner,Product_TA ProductsDB.Products.PlayerBanner_PixelFire,Pixel Fire
+4960,PremiumInventory,Product_TA ProductsDB.Products.CrateUnlocked_Spring20,Golden Gift Basket '22
 4961,Antenna,Product_TA ProductsDB.Products.antenna_snobro,Mr. Floeberg
 4962,Wheels,Product_TA ProductsDB.Products.wheel_spiker,Ruinator
 4964,Skin,Product_TA ProductsDB.Products.skin_force_huntress,Breakout: Huntress
@@ -3826,9 +3829,12 @@
 6031,Skin,Product_TA ProductsDB.Products.skin_ncrfd_ocm,NASCAR Ford Mustang: Roush Fenway Racing #6
 6032,Skin,Product_TA ProductsDB.Products.skin_ncrfd_sff,NASCAR Ford Mustang: Stewart-Haas Racing #10
 6033,GoalExplosion,Product_TA ProductsDB.Products.explosion_horse_hind_legs,Night-Mare
+6034,Boost,Product_TA ProductsDB.Products.boost_ninjastar_psplus,Ninja Star BL
 6035,Skin,Product_TA ProductsDB.Products.skin_fracture_haa,Formula 1 2021: Haas 2021
+6036,Hat,Product_TA ProductsDB.Products.hat_stars_psplus,Seeing Stars BL
 6037,Skin,Product_TA ProductsDB.Products.skin_fracture_ast,Formula 1 2021: Aston Martin 2021
 6039,Skin,Product_TA ProductsDB.Products.skin_fracture_wil,Formula 1 2021: Williams 2021
+6040,Wheels,Product_TA ProductsDB.Products.wheel_toon_psplus,Spoof Star BL
 6042,Skin,Product_TA ProductsDB.Products.skin_fracture_red,Formula 1 2021: Red Bull 2021
 6043,Wheels,Product_TA ProductsDB.Products.wheel_ronB,McLaren 570S (Silver)
 6044,Skin,Product_TA ProductsDB.Products.skin_ncrfd_pzl,NASCAR Ford Mustang: Team Penske #22
@@ -3873,6 +3879,7 @@
 6104,Skin,Product_TA ProductsDB.Products.skin_Rattrap_stripes_all,Outlaw: Stripes
 6105,Skin,Product_TA ProductsDB.Products.skin_Rattrap_Thick_all,Outlaw: Block Trim
 6106,EngineAudio,Product_TA ProductsDB.Products.engineaudio_rattrap,Outlaw
+6108,Skin,Product_TA ProductsDB.Products.skin_octane_dream_psplus,Octane: Starscape Jr. BL
 6110,Boost,Product_TA ProductsDB.Products.boost_drofb,Union Beams
 6111,Boost,Product_TA ProductsDB.Products.boost_lava_xbg,Magmus XS
 6116,Wheels,Product_TA ProductsDB.Products.wheel_bluemoon_xbb,Zefram
@@ -4190,6 +4197,7 @@
 6825,Skin,Product_TA ProductsDB.Products.skin_grain_KarmineCorp,Fennec: Karmine Corp (Home)
 6826,Skin,Product_TA ProductsDB.Products.skin_musclecar_KarmineCorp,Dominus: Karmine Corp (Home)
 6827,Skin,Product_TA ProductsDB.Products.skin_octane_KarmineCorp,Octane: Karmine Corp (Home)
+6828,Skin,Product_TA ProductsDB.Products.skin_grain_thornbrow_anim,Fennec: RLCS 2021-22
 6829,Hat,Product_TA ProductsDB.Products.hat_hqc,Harley Quinn
 6831,Skin,Product_TA ProductsDB.Products.skin_ncrfd_hpt,NASCAR Ford Mustang: Stewart-Haas Racing #14
 6832,PremiumInventory,Product_TA ProductsDB.Products.crateunlocked_AT5,Accolade V
@@ -4326,6 +4334,7 @@
 6983,EngineAudio,Product_TA ProductsDB.Products.engineaudio_elm,Ford Mustang Mach-E RLE
 6984,Wheels,Product_TA ProductsDB.Products.wheel_turek_infinite,Canister: Infinite
 6987,Skin,Product_TA ProductsDB.Products.skin_norton_gust,Nexus: Sally
+6988,Wheels,Product_TA ProductsDB.Products.wheel_cured,Pirelli
 6989,Skin,Product_TA ProductsDB.Products.skin_ran_a,McLaren 765LT: McLaren 765 (Silver)
 6990,Skin,Product_TA ProductsDB.Products.skin_Octane_FBarz,Octane: Arizona Cardinals
 6991,Skin,Product_TA ProductsDB.Products.skin_Octane_FBatl,Octane: Atlanta Falcons
@@ -4379,6 +4388,7 @@
 7049,Wheels,Product_TA ProductsDB.Products.wheel_tank_flare,Enjin: Roasted
 7050,Skin,Product_TA ProductsDB.Products.skin_force_frosted,Breakout: Ombre
 7051,Hat,Product_TA ProductsDB.Products.hat_core,Corbital
+7052,Body,Product_TA ProductsDB.Products.body_cured,Formula 1 2022
 7053,Skin,Product_TA ProductsDB.Products.skin_elm_km,Ford Mustang Mach-E RLE: 98
 7054,Skin,Product_TA ProductsDB.Products.skin_norton_huntress,Nexus: Huntress
 7055,Skin,Product_TA ProductsDB.Products.skin_norton_wings,Nexus: Wings
@@ -4388,6 +4398,7 @@
 7059,Wheels,Product_TA ProductsDB.Products.wheel_sunny,Happy Sunbeam
 7060,Skin,Product_TA ProductsDB.Products.skin_norton_flames,Nexus: Flames
 7061,Skin,Product_TA ProductsDB.Products.skin_norton_lightning,Nexus: Lightning
+7062,Wheels,Product_TA ProductsDB.Products.wheel_scar,Next Gen Goodyear Racing
 7065,Wheels,Product_TA ProductsDB.Products.wheel_bugger_inverted,Prop-L: Inverted
 7068,Skin,Product_TA ProductsDB.Products.pack_nflanimskins,2021 NFL Fan Pass
 7069,Hat,Product_TA ProductsDB.Products.pack_nflhelmets,2021 NFL Fan Pass
@@ -4618,8 +4629,11 @@
 7334,Wheels,Product_TA ProductsDB.Products.wheel_starry,E-Zeke
 7335,Skin,Product_TA ProductsDB.Products.skin_octane_hallowed,Octane: Reviver
 7336,Body,Product_TA ProductsDB.Products.body_Maui,Nomad
+7337,Body,Product_TA ProductsDB.Products.body_scar_b,NASCAR Next Gen Chevrolet Camaro
+7338,Body,Product_TA ProductsDB.Products.body_scar_a,NASCAR Next Gen Ford Mustang
 7339,Skin,Product_TA ProductsDB.Products.skin_squishy,Slurpee
 7340,Hat,Product_TA ProductsDB.Products.hat_tiger,Tiny Tiger
+7341,Body,Product_TA ProductsDB.Products.body_scar_c,NASCAR Next Gen Toyota Camry
 7342,Hat,Product_TA ProductsDB.Products.hat_fluffy,Nomster
 7348,Antenna,Product_TA ProductsDB.Products.antenna_rattly,Rattler
 7349,Wheels,Product_TA ProductsDB.Products.wheel_bennie,Artifuss
@@ -4713,16 +4727,80 @@
 7459,Skin,Product_TA ProductsDB.Products.skin_maui_huntress,Nomad: Huntress
 7460,Skin,Product_TA ProductsDB.Products.skin_octane_audio,Octane: Lo Freq
 7461,EngineAudio,Product_TA ProductsDB.Products.engineaudio_maui,Nomad
+7462,Skin,Product_TA ProductsDB.Products.skin_octane_elvesb,Octane: Fred
 7463,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_turtlerun,Speedy Turtle
 7464,Wheels,Product_TA ProductsDB.Products.wheel_starry_Inverted,E-Zeke: Inverted
-7465,Skin,Product_TA ProductsDB.Products.skin_maui_jerm,Nomad GXT: Blinkpad
+7465,Skin,Product_TA ProductsDB.Products.skin_maui_jerm,Nomad: Blinkpad
 7466,MusicStingers,Product_TA ProductsDB.Products.mx_album_bhm2022,Behind The Samples
 7467,MusicStingers,Product_TA ProductsDB.Products.mx_anthems_bhm2022_01,You're Getting A Little Too Smart
 7468,MusicStingers,Product_TA ProductsDB.Products.mx_anthems_bhm2022_02,Funky Worm
 7469,MusicStingers,Product_TA ProductsDB.Products.mx_anthems_bhm2022_03,Amen Brother
 7470,MusicStingers,Product_TA ProductsDB.Products.Anthem_S5_Feature_02,Shinigami Eyes
 7471,GoalExplosion,Product_TA ProductsDB.Products.explosion_TBM,The Batman
+7473,Hat,Product_TA ProductsDB.Products.hat_elvesb,Big Bite
 7475,Hat,Product_TA ProductsDB.Products.hat_anvil,Anvil
 7477,Body,Product_TA ProductsDB.Products.body_Maui_t2,Nomad GXT
+7479,Wheels,Product_TA ProductsDB.Products.wheel_alpine_infinite,Rival: Infinite
 7487,EngineAudio,Product_TA ProductsDB.Products.engineaudio_maser,Mamba
+7496,EngineAudio,Product_TA ProductsDB.Products.engineaudio_rage,Lamborghini Countach LPI 800-4
+7498,Skin,Product_TA ProductsDB.Products.skin_scar_c_01,NASCAR Next Gen Toyota Camry: Joe Gibbs Racing #19
+7499,Skin,Product_TA ProductsDB.Products.skin_scar_a_01,NASCAR Next Gen Ford Mustang: Stewart-Haas Racing #4
+7500,Skin,Product_TA ProductsDB.Products.skin_scar_a_03,NASCAR Next Gen Ford Mustang: Front Row Motorsports #34
+7501,EngineAudio,Product_TA ProductsDB.Products.engineaudio_scar_a,NASCAR Next Gen Ford Mustang
+7502,EngineAudio,Product_TA ProductsDB.Products.engineaudio_scar_b,NASCAR Next Gen Chevrolet Camaro
+7503,EngineAudio,Product_TA ProductsDB.Products.engineaudio_scar_c,NASCAR Next Gen Toyota Camry
 7511,Wheels,Product_TA ProductsDB.Products.wheel_latchkey,Cupola
+7512,Body,Product_TA ProductsDB.Products.body_rage,Lamborghini Countach LPI 800-4
+7513,Skin,Product_TA ProductsDB.Products.skin_scar_b_01,NASCAR Next Gen Chevrolet Camaro: Hendrick Motorsports #5
+7514,Skin,Product_TA ProductsDB.Products.skin_scar_b_02,NASCAR Next Gen Chevrolet Camaro: Spire Motorsports #7
+7515,Skin,Product_TA ProductsDB.Products.skin_scar_b_03,NASCAR Next Gen Chevrolet Camaro: Trackhouse Racing #1
+7516,Wheels,Product_TA ProductsDB.Products.wheel_rage_A,Lamborghini Countach LPI 800-4
+7517,Skin,Product_TA ProductsDB.Products.skin_rage_a,Lamborghini Countach LPI 800-4: Argento Luna
+7518,Skin,Product_TA ProductsDB.Products.skin_scar_b_04,NASCAR Next Gen Chevrolet Camaro: Richard Childress Racing #8
+7523,Wheels,Product_TA ProductsDB.Products.wheel_rage_B,Lamborghini Countach 70?s
+7524,Wheels,Product_TA ProductsDB.Products.wheel_elvesb,Brainfreeze
+7526,Skin,Product_TA ProductsDB.Products.skin_ran_fronds,McLaren 765LT: Miami Grand Prix
+7534,MusicStingers,Product_TA ProductsDB.Products.album_anthem_whm2022,Behind the Scenes
+7535,MusicStingers,Product_TA ProductsDB.Products.anthem_whm2022_01,What's Up?
+7536,MusicStingers,Product_TA ProductsDB.Products.anthem_whm2022_02,Get the Party Started
+7537,MusicStingers,Product_TA ProductsDB.Products.anthem_whm2022_03,Open Your Eyes
+7538,Hat,Product_TA ProductsDB.Products.Hat_racinghelmet_fronds,Miami Grand Prix Helmet
+7539,Skin,Product_TA ProductsDB.Products.skin_scar_a_02,NASCAR Next Gen Ford Mustang: RFK Racing #17
+7540,Skin,Product_TA ProductsDB.Products.skin_scar_a_04,NASCAR Next Gen Ford Mustang: Team Penske #12
+7541,Antenna,Product_TA ProductsDB.Products.flag_mc_candyland,Candyland
+7544,Antenna,Product_TA ProductsDB.Products.flag_mc_ggmagree,GG Magree
+7546,Hat,Product_TA ProductsDB.Products.hat_futureglasses_psplus,ROBO-Visor Plus
+7547,Wheels,Product_TA ProductsDB.Products.wheel_crote_psplus,Clodhopper Plus
+7551,Skin,Product_TA ProductsDB.Products.skin_triangleflip_psplus,Shield Glitch Plus
+7552,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_a_01,Stewart-Haas Racing #4
+7553,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_a_02,RFK Racing #17
+7554,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_a_03,Front Row Motorsports #34
+7555,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_a_04,Team Penske #12
+7556,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_b_01,Hendrick Motorsports #5
+7557,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_b_02,Spire Motorsports #7
+7558,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_b_03,Trackhouse Racing #1
+7559,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_b_04,Richard Childress Racing #8
+7560,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_scar_c_01,Joe Gibbs Racing #19
+7561,Boost,Product_TA ProductsDB.Products.boost_techy_psplus,Virtual Wave Plus
+7568,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_fronds,Miami Grand Prix
+7571,MusicStingers,Product_TA ProductsDB.Products.anthem_shell_01,FALL (Clean)
+7572,Antenna,Product_TA ProductsDB.Products.flag_fronds,Miami Grand Prix Flag
+7577,Boost,Product_TA ProductsDB.Products.boost_butterflies,Monarch
+7580,Antenna,Product_TA ProductsDB.Products.antenna_springy,Sapling
+7582,Hat,Product_TA ProductsDB.Products.hat_springy,Monarch
+7583,Skin,Product_TA ProductsDB.Products.skin_octane_springy,Octane: Springtide
+7584,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_springy,Smiling Sapling
+7586,Skin,Product_TA ProductsDB.Products.Skin_Margarine,Flutterby
+7587,Wheels,Product_TA ProductsDB.Products.wheel_springy,Florescence
+7592,PlayerBanner,Product_TA ProductsDB.Products.playerbanner_rage,Lamborghini Countach LPI 800-4
+7596,EngineAudio,Product_TA ProductsDB.Products.Engineaudio_Cured,Formula 1 2022
+7601,PlayerBanner,Product_TA ProductsDB.Products.PlayerBanner_fractureB,Formula 1 2022
+7617,MusicStingers,Product_TA ProductsDB.Products.album_anthem_madness,Madness
+7618,MusicStingers,Product_TA ProductsDB.Products.anthem_saxsquatch_madness,Madness
+7622,Skin,Product_TA ProductsDB.Products.skin_cured_01,Formula 1 2022: Alfa Romeo 2022
+7623,Skin,Product_TA ProductsDB.Products.skin_cured_05,Formula 1 2022: Ferrari 2022
+7624,Skin,Product_TA ProductsDB.Products.skin_cured_07,Formula 1 2022: McLaren 2022
+7631,Skin,Product_TA ProductsDB.Products.skin_cured_011,Formula 1 2022: McLaren Miami 2022
+7643,MusicStingers,Product_TA ProductsDB.Products.anthem_maxrepka_madness,Madness
+7644,Skin,Product_TA ProductsDB.Products.skin_cured_02,Formula 1 2022: AlphaTauri 2022
+7646,Skin,Product_TA ProductsDB.Products.skin_cured_09,Formula 1 2022: Red Bull 2022

--- a/rlbot_gui/gui/json/standard-maps.json
+++ b/rlbot_gui/gui/json/standard-maps.json
@@ -17,7 +17,6 @@
     "Mannfield_Night",
     "ChampionsField_Day",
     "BeckwithPark_Stormy",
-    "BeckwithPark_Midnight",
     "UrbanCentral_Night",
     "UrbanCentral_Dawn",
     "UtopiaColiseum_Dusk",

--- a/rlbot_gui/story/bots-base.json
+++ b/rlbot_gui/story/bots-base.json
@@ -89,10 +89,10 @@
         "type": "rlbot",
         "path": ["$RLBOTPACKROOT", "RLBotPack", "The Forsaken", "Lanfear.cfg"]
     },
-    "manticore": {
-        "name": "Manticore",
+    "phoenix": {
+        "name": "Phoenix",
         "type": "rlbot",
-        "path": ["$RLBOTPACKROOT", "RLBotPack", "manticore", "manticore.cfg"]
+        "path": ["$RLBOTPACKROOT", "RLBotPack", "PhoenixCS", "phoenix.cfg"]
     },
     "atlas": {
         "name": "Atlas",

--- a/rlbot_gui/story/story-default-with-cmaps.json
+++ b/rlbot_gui/story/story-default-with-cmaps.json
@@ -184,7 +184,7 @@
                 {
                     "id": "CHAMP-3",
                     "humanTeamSize": 3,
-                    "opponentBots": ["kamael", "diablo", "lanfear", "manticore", "atlas"],
+                    "opponentBots": ["kamael", "diablo", "lanfear", "phoenix", "atlas"],
                     "map": "ChampionsField_Day",
                     "display": "These are mythical and magical cars. Can you take them on in a 3v5?"
                 },

--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -181,7 +181,7 @@
                 {
                     "id": "CHAMP-3",
                     "humanTeamSize": 3,
-                    "opponentBots": ["kamael", "diablo", "lanfear", "manticore", "atlas"],
+                    "opponentBots": ["kamael", "diablo", "lanfear", "phoenix", "atlas"],
                     "map": "ChampionsField_Day",
                     "display": "These are mythical and magical cars. Can you take them on in a 3v5?"
                 },

--- a/rlbot_gui/story/story-easy-with-cmaps.json
+++ b/rlbot_gui/story/story-easy-with-cmaps.json
@@ -173,7 +173,7 @@
                 {
                     "id": "CHAMP-3",
                     "humanTeamSize": 3,
-                    "opponentBots": ["diablo", "lanfear", "manticore", "atlas"],
+                    "opponentBots": ["diablo", "lanfear", "phoenix", "atlas"],
                     "map": "ChampionsField_Day",
                     "display": "These are mythical and magical cars. Can you take them on in a 3v4?"
                 },

--- a/rlbot_gui/story/story-easy.json
+++ b/rlbot_gui/story/story-easy.json
@@ -170,7 +170,7 @@
                 {
                     "id": "CHAMP-3",
                     "humanTeamSize": 3,
-                    "opponentBots": ["diablo", "lanfear", "manticore", "atlas"],
+                    "opponentBots": ["diablo", "lanfear", "phoenix", "atlas"],
                     "map": "ChampionsField_Day",
                     "display": "These are mythical and magical cars. Can you take them on in a 3v4?"
                 },

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.135'
+__version__ = '0.0.136'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
See commits.
- Manticore was removed from the botpack and Phoenix is a good replacement (also fits the mythical theme, also made by East)
- a lot of people are having issues with Nexto on BeckwithPark_Midnight so removed it temporarily until the ghost boost pad is fixed