### PR TITLE
Better missing packages warnings & more

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -428,7 +428,7 @@ def get_match_options():
 def install_package(package_string):
     exit_code = subprocess.call([sys.executable, "-m", "pip", "install", '--upgrade', '--no-warn-script-location', package_string])
     print(exit_code)
-    return {'exitCode': exit_code, 'package': package_string}
+    return {'exitCode': exit_code, 'packages': [package_string]}
 
 
 @eel.expose
@@ -440,9 +440,10 @@ def install_requirements(config_path):
 
     if bundle.requirements_file:
         exit_code = install_requirements_file(bundle.requirements_file)
-        return {'exitCode': exit_code, 'package': bundle.requirements_file}
+        installed_packages = [r.line for r in bundle.get_missing_python_packages() + bundle.get_python_packages_needing_upgrade()]
+        return {'exitCode': exit_code, 'packages': installed_packages}
     else:
-        return {'exitCode': 1, 'package': None}
+        return {'exitCode': 1, 'packages': None}
 
 
 def get_last_botpack_commit_id():

--- a/rlbot_gui/gui/css/style.css
+++ b/rlbot_gui/gui/css/style.css
@@ -277,6 +277,7 @@ button.icon-button {
   margin-top: 15px;
   margin-bottom: 10px;
   max-width: 250px;
+  max-height: 250px;
 }
 
 .md-dialog{

--- a/rlbot_gui/gui/js/bot-card-vue.js
+++ b/rlbot_gui/gui/js/bot-card-vue.js
@@ -15,16 +15,7 @@ export default {
 	},
 	template: /*html*/`
 		<draggable v-model="draggableModel" :options="draggableOptions" style="display: inline;">
-			<runnable-card :runnable="bot" :disabled="disabled" :class="{draggable: draggable}" @click="$emit('click')">
-				<img v-if="bot.logo" :src="bot.logo">
-				<img v-else class="darkened" :src="bot.image">
-				<span class="bot-name">
-					{{ bot.name }}
-					<span v-if="bot.uniquePathSegment" class="unique-bot-identifier">
-						({{ bot.uniquePathSegment }})
-					</span>
-				</span>
-			</runnable-card>
+			<runnable-card :runnable="bot" v-bind="[$props,$attrs]" :class="{draggable: draggable}" @click="$emit('click')">
 		</draggable>
 	`,
 	computed: {

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -724,10 +724,20 @@ export default {
 
 		onInstallationComplete: function (result) {
 			let message = result.exitCode === 0 ? 'Successfully installed ' : 'Failed to install ';
-			message += result.package;
+			message += result.packages.join(", ");
 			this.snackbarContent = message;
 			this.showSnackbar = true;
 			this.showProgressSpinner = false;
+
+			// remove missing packages from other bots and maybe hide the yellow triangle
+			if (result.exitCode === 0) {
+				for (const bot of this.botPool) if (bot.missing_python_packages) {
+					bot.missing_python_packages = bot.missing_python_packages.filter(pkg => !result.packages.includes(pkg));
+					if (bot.missing_python_packages.length == 0 && bot.warn == "pythonpkg") {
+						bot.warn = null;
+					}
+				}
+			}
 		},
 		installPackage: function () {
 			this.showProgressSpinner = true;

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -144,10 +144,13 @@ export default {
 			<span class="rlbot-card-header">Match Settings</span>
 			<div style="display:flex; align-items: flex-end">
 
-				<div>
+				<div style="max-width: 250px">
 					<label for="map_selection">Map</label>
 					<b-form-select v-model="matchSettings.map" id="map_selection" @change="updateBGImage(matchSettings.map)">
-						<b-form-select-option v-for="map in matchOptions.map_types" :key="map" v-bind:value="map">{{map}}</b-form-select-option>
+						<b-form-select-option v-for="map in matchOptions.map_types" :key="map" v-bind:value="map">
+							{{map}}
+							<span v-if="map == 'BeckwithPark_Midnight'">(DO NOT SELECT)</span> <!-- temporary until https://github.com/RLBot/RLBot/issues/523 is fixed -->
+						</b-form-select-option>
 					</b-form-select>
 				</div>
 				<div class="ml-2">

--- a/rlbot_gui/gui/js/runnable-card-vue.js
+++ b/rlbot_gui/gui/js/runnable-card-vue.js
@@ -1,12 +1,26 @@
 export default {
 	name: 'runnable-card',
-	props: ['runnable', 'disabled'],
+	props: {
+		runnable: Object,
+		disabled: Boolean,
+		removable: Boolean,
+		hidewarning: Boolean,
+	},
 	template: /*html*/`
 		<b-card class="bot-card" @click="disabled || $emit('click')" :class="{disabled: disabled}">
 
-			<slot>{{ runnable.name }}</slot>
+			<slot>
+				<img v-if="runnable.logo" :src="runnable.logo">
+				<img v-else class="darkened" :src="runnable.image">
+				<span class="bot-name">
+					{{ runnable.name }}
+					<span v-if="runnable.uniquePathSegment" class="unique-bot-identifier">
+						&nbsp;({{ runnable.uniquePathSegment }})
+					</span>
+				</span>
+			</slot>
 
-			<b-button size="sm" class="icon-button warning-icon" v-if="runnable.warn" variant="outline-warning"
+			<b-button size="sm" class="icon-button warning-icon" v-if="runnable.warn && !hidewarning" variant="outline-warning"
 						@click.stop="$store.commit('setActiveBot', runnable)" v-b-modal.language-warning-modal>
 				<b-icon icon="exclamation-triangle-fill"/>
 			</b-button>
@@ -14,6 +28,10 @@ export default {
 			<b-button size="sm" variant="outline-primary" class="bot-hover-reveal icon-button" v-if="runnable.info"
 						@click.stop="$store.commit('setActiveBot', runnable)" v-b-modal.bot-info-modal>
 				<b-icon icon="info-circle"/>
+			</b-button>
+
+			<b-button v-if="removable" size="sm" variant="outline-danger" class="icon-button" @click="$emit('remove')">
+				<b-icon icon="x"></b-icon>
 			</b-button>
 
 		</b-card>

--- a/rlbot_gui/gui/js/script-card-vue.js
+++ b/rlbot_gui/gui/js/script-card-vue.js
@@ -11,7 +11,10 @@ export default {
 			<b-form inline>
 				<b-form-checkbox v-model="script.enabled" class="script-switch" switch :disabled="disabled">
 					<img :src="script.logo">
-					<span>{{ script.name }}</span>
+					{{ script.name }}
+					<span v-if="script.uniquePathSegment" class="unique-bot-identifier">
+						&nbsp;({{ script.uniquePathSegment }})
+					</span>
 				</b-form-checkbox>
 			</b-form>
 		</runnable-card>

--- a/rlbot_gui/gui/js/team-card-vue.js
+++ b/rlbot_gui/gui/js/team-card-vue.js
@@ -1,20 +1,21 @@
+import RunnableCard from './runnable-card-vue.js'
+
 export default {
 	name: 'team-card',
+    components: {
+		'runnable-card': RunnableCard,
+	},
 	props: ['value', 'team-class'],
 	template: `
 		<b-card class="team-card md-elevation-8" :class="teamClass">
             <div class="team-label">
                 <slot></slot>
             </div>
-            <draggable v-model="team" class="team-entries" :options="{group:'bots'}">
-                <b-card class="bot-card draggable center-flex md-elevation-3" v-for="(bot, index) in team">
-                    <img v-if="!bot.logo" class="darkened" v-bind:src="bot.image">
-                    <img v-if="bot.logo" v-bind:src="bot.logo">
-                    <span class="bot-name">{{ bot.name }} <span v-if="bot.uniquePathSegment" class="unique-bot-identifier">({{ bot.uniquePathSegment }})</span></span>
-                    <b-button size="sm" variant="outline-danger" class="icon-button" @click="team.splice(index, 1)">
-                        <b-icon icon="x"></b-icon>
-                    </b-button>
-                </b-card>
+            <draggable v-model="team" class="team-entries" :options="{group:'bots'}" @change="$event.added ? $emit('botadded', $event.added.element) : 0">
+                <runnable-card
+                    v-for="(bot, index) in team" :runnable="bot" class="draggable"
+                    removable @remove="team.splice(index, 1)">
+                </runnable-card>
             </draggable>
         </b-card>
     `,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.136'
+__version__ = '0.0.137'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Since some users are oblivious to missing packages warnings
- show compatibility warning modal when such a bot is added to a team
- display info and warning icons on bots in team cards
- hide yellow triangles on bots that are no longer missing packages

Since a decent amount of users are manually selecting BeckwithPark_Midnight, added _(DO NOT SELECT)_ warning next to it