### PR TITLE
[Fix] Fix bug when tags included empty strings

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -263,7 +263,7 @@ def read_info(bundle: RunnableConfigBundle):
             'fun_fact': bundle.base_agent_config.get(details_header, 'fun_fact'),
             'github': bundle.base_agent_config.get(details_header, 'github'),
             'language': bundle.base_agent_config.get(details_header, 'language'),
-            'tags': [tag.strip() for tag in raw_tags.split(',')] if raw_tags else [],
+            'tags': [tag.strip() for tag in raw_tags.split(',') if not tag.isspace()] if raw_tags else [],
         }
     return None
 

--- a/rlbot_gui/gui/js/bot-pool-vue.js
+++ b/rlbot_gui/gui/js/bot-pool-vue.js
@@ -84,12 +84,12 @@ export default {
 			if (runnable.type === 'script' && !category.displayScriptDependencies && runnable.enabled)
 				return true;
 
-			let allowedTags = runnable.type === 'script' ? category.scripts : category.bots;
-			if (allowedTags) {
-				if (allowedTags === '*') {
+			let allowedTag = runnable.type === 'script' ? category.scripts : category.bots;
+			if (allowedTag) {
+				if (allowedTag === '*') {
 					return true;
 				}
-				return runnable.info.tags.some(tag => allowedTags.includes(tag));
+				return runnable.info.tags.includes(allowedTag);
 			}
 			return false;
 		},

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.142'
+__version__ = '0.0.143'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
The bot King by CodeRed currently has tags: 
```
tags = 1v1, teamplay,
```
The extra comma results in a empty tag. Since every string contains the empty string, King shows up in all categories.

This fix will make sure we discard tags consisting only of whitespace. Additionally, I changed the category filtering to compare the tags to the entire allowed tag. Before, one tag just had to be a substring of the allowed tag for the bot to be shown.