### PR TITLE
[Fix/Story mode] Fix INTRO-2 map and make adjust recruitment requirements

### DIFF
--- a/rlbot_gui/gui/js/story-challenges.js
+++ b/rlbot_gui/gui/js/story-challenges.js
@@ -276,12 +276,18 @@ export default {
         recruit_list: function () {
             let recruits = {};
 
+            // You can recruit bots from mandatory challenges of
+            // a city once all the mandatory challenges of that city is complete.
             for (let city of Object.keys(this.challenges)) {
-                if (this.getCityState(city) != CITY_STATE.DONE) {
+                const state = this.getCityState(city);
+                if (state === CITY_STATE.LOCKED || state === CITY_STATE.OPEN) {
                     continue;
                 }
                 for (let challenge of this.challenges[city]) {
-                    // This challenge was completed so opponents are available
+                    if (challenge.optional) {
+                        continue
+                    }
+                    // This challenge was mandatory and now completed so opponents are available
                     const botIds = challenge.opponentBots;
                     for (let botId of botIds) {
                         let bot = Object.assign({}, this.bots_config[botId]);

--- a/rlbot_gui/story/story-default.json
+++ b/rlbot_gui/story/story-default.json
@@ -21,7 +21,7 @@
                     "humanTeamSize": 1,
                     "opponentBots": ["noobbot"],
                     "optional": true,
-                    "map": "BeckwithPark_Dawn",
+                    "map": "Farmstead",
                     "display": "A training partner challenges you"
                 }
             ]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.150'
+__version__ = '0.0.151'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Fixes
- INTRO-2 map changed to Farmstead (BeckwithPark_Dawn does not exist lol)
- You can now recruit bots from mandatory challenges of a city once all the mandatory challenges of that city is complete