### PR TITLE
More community events improvements

### DIFF
--- a/rlbot_gui/gui/js/community-events-vue.js
+++ b/rlbot_gui/gui/js/community-events-vue.js
@@ -1,7 +1,7 @@
 export default {
     name: 'community-events',
     template: /*html*/`
-        <b-modal title="Community Events" id="community-events" size="lg" centered ok-only>
+        <b-modal title="Community Events" id="community-events" size="xl" centered ok-only>
             <div v-if="events.length == 0">
                 <p>There are no community events at this time.</p>
             </div>

--- a/rlbot_gui/gui/js/community-events-vue.js
+++ b/rlbot_gui/gui/js/community-events-vue.js
@@ -1,23 +1,28 @@
 export default {
     name: 'community-events',
     template: /*html*/`
-		<b-modal title="Community Events" id="community-events" size="lg" centered ok-only>
-			<div v-if="events.length == 0">
-				<p>There are no community events at this time.</p>
-			</div>
-			<div v-else v-for="event in events">
-				<h3>{{ event.name }}</h3>
-                <p v-if="event.timeUntilMs > 0" class="mb-1">
-                    <b-icon icon="calendar-plus"/> Starts in <b>{{ event.timeUntil }}</b> ({{ event.time }})
-                </p>
-                <p v-else class="mb-1">
-                    <b-icon icon="alarm"/> Started <b>{{ event.timeUntil }}</b> ago, but you can still join!
-                </p>
-				<p>
-                    <b-icon icon="geo"/> <a :href="event.location" target="_blank">{{ event.location }}</a>
-                </p>
-			</div>
-		</b-modal>
+        <b-modal title="Community Events" id="community-events" size="lg" centered ok-only>
+            <div v-if="events.length == 0">
+                <p>There are no community events at this time.</p>
+            </div>
+            <div v-else v-for="event in events">
+                <div class="d-flex align-items-center">
+                    <img v-if="event.logo" :src="event.logo" class="mr-3" style="max-width: 100%; max-height: 100px;"/>
+                    <div>
+                        <h3>{{ event.name }}</h3>
+                        <p v-if="event.timeUntilMs > 0" class="mb-1">
+                            <b-icon icon="calendar-plus"/> Starts in <b>{{ event.timeUntil }}</b> ({{ event.time }})
+                        </p>
+                        <p v-else class="mb-1">
+                            <b-icon icon="alarm"/> Started <b>{{ event.timeUntil }}</b> ago, but you can still join!
+                        </p>
+                        <p>
+                            <b-icon icon="geo"/> <a :href="event.location" target="_blank">{{ event.location }}</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </b-modal>
 	`,
     data() {
         return {
@@ -32,40 +37,41 @@ export default {
             const start = event.start.dateTime;
             let new_date = new Date(start);
 
-            try {
-                const recurrence = event.recurrence[0].split(";");
-                const rec_type = recurrence[0].split("=")[1];
-                const interval = recurrence[2].split("=")[1];
-                const end_date_type = recurrence[2].split("=")[0];
-                const end_date_raw = recurrence[2].split("=")[1];
-                let end_date = new Date(new_date);
-                if (end_date_type == "COUNT") {
+            if (event.recurrence) {
+                try {
+                    const recurrence = event.recurrence[0].split(";");
+                    const rec_type = recurrence[0].split("=")[1];
+                    const interval = recurrence[2].split("=")[1];
+                    const end_date_type = recurrence[2].split("=")[0];
+                    const end_date_raw = recurrence[2].split("=")[1];
+                    let end_date = new Date(new_date);
+                    if (end_date_type == "COUNT") {
+                        if (rec_type == "WEEKLY") {
+                            end_date.setDate(new_date.getDate() + 7 * interval * end_date_raw);
+                        } else if (rec_type == "MONTHLY") {
+                            end_date.setDate(new_date.getDate() + 4 * interval * end_date_raw);
+                        }
+                    } else {
+                        end_date.setDate(end_date_raw);
+                    }
                     if (rec_type == "WEEKLY") {
-                        end_date.setDate(new_date.getDate() + 7 * interval * end_date_raw);
+                        while (new_date <= end_date) {
+                            if (new_date > today) {
+                                break;
+                            }
+                            new_date.setDate(new_date.getDate() + 7);
+                        }
                     } else if (rec_type == "MONTHLY") {
-                        end_date.setDate(new_date.getDate() + 4 * interval * end_date_raw);
-                    }
-                } else {
-                    end_date.setDate(end_date_raw);
-                }
-                if (rec_type == "WEEKLY") {
-                    while (new_date <= end_date) {
-                        if (new_date > today) {
-                            break;
+                        while (new_date <= end_date) {
+                            if (new_date > today) {
+                                break;
+                            }
+                            new_date.setDate(new_date.getDate() + 4);
                         }
-                        new_date.setDate(new_date.getDate() + 7);
                     }
-                } else if (rec_type == "MONTHLY") {
-                    while (new_date <= end_date) {
-                        if (new_date > today) {
-                            break;
-                        }
-                        new_date.setDate(new_date.getDate() + 4);
-                    }
+                } catch (e) {
+                    console.error("Error checking recurrence:" + e);
                 }
-            }
-            catch (e) {
-                console.error("Error checking recurrence:" + e);
             }
 
             const time_untils = new_date.getTime() - today.getTime();
@@ -128,12 +134,23 @@ export default {
                         // convert this to something human readable, like "in 2 days"
                         const format = this.formatFromNow(Math.abs(time_until_ms));
 
+                        let logo =
+                          event.description && event.description.includes("logo:")
+                            ? event.description
+                                .split("logo:")[1]
+                                .replace("\n", "")
+                                .replace("</a>", "")
+                                .split(">")[1]
+                                .trim()
+                            : null;
+
                         this.events.push({
                             name: names,
                             location: event.location,
                             time: new_date.toLocaleString(),
                             timeUntil: format,
                             timeUntilMs: time_until_ms,
+                            logo: logo,
                         });
                     }
 

--- a/rlbot_gui/gui/js/community-events-vue.js
+++ b/rlbot_gui/gui/js/community-events-vue.js
@@ -7,7 +7,7 @@ export default {
             </div>
             <div v-else v-for="event in events">
                 <div class="d-flex align-items-center">
-                    <img v-if="event.logo" :src="event.logo" class="mr-3" style="max-width: 100%; max-height: 100px;"/>
+                    <img v-if="event.logo" :src="event.logo" class="mr-3" style="max-width: 100%; max-height: 150px;"/>
                     <div>
                         <h3>{{ event.name }}</h3>
                         <p v-if="event.timeUntilMs > 0" class="mb-1">

--- a/rlbot_gui/gui/js/community-events-vue.js
+++ b/rlbot_gui/gui/js/community-events-vue.js
@@ -170,8 +170,8 @@ export default {
                         return new Date(a.timeUntilMs) - new Date(b.timeUntilMs);
                     });
 
-                    // only show the first 3
-                    this.events = this.events.slice(0, 3);
+                    // only show the first 4
+                    this.events = this.events.slice(0, 4);
                 });
             });
         },

--- a/rlbot_gui/gui/js/community-events-vue.js
+++ b/rlbot_gui/gui/js/community-events-vue.js
@@ -145,7 +145,6 @@ export default {
                                 .split("href=\"")[1]
                                 .split("\"")[0]
                             : null;
-                        console.log(logo);
 
                         let description = event.description
                             ? event.description

--- a/rlbot_gui/gui/js/community-events-vue.js
+++ b/rlbot_gui/gui/js/community-events-vue.js
@@ -19,6 +19,9 @@ export default {
                         <p>
                             <b-icon icon="geo"/> <a :href="event.location" target="_blank">{{ event.location }}</a>
                         </p>
+                        <p v-if="event.moreInfo">
+                            <b-icon icon="info-circle"/> <a :href="event.moreInfo" target="_blank">More info</a>
+                        </p>
                     </div>
                 </div>
             </div>
@@ -139,9 +142,17 @@ export default {
                             ? event.description
                                 .split("logo:")[1]
                                 .replace("\n", "")
-                                .replace("</a>", "")
-                                .split(">")[1]
-                                .trim()
+                                .split("href=\"")[1]
+                                .split("\"")[0]
+                            : null;
+                        console.log(logo);
+
+                        let description = event.description
+                            ? event.description
+                                .split("logo:")[0]
+                                .replace("\n", "")
+                                .split("href=\"")[1]
+                                .split("\"")[0]
                             : null;
 
                         this.events.push({
@@ -150,6 +161,7 @@ export default {
                             time: new_date.toLocaleString(),
                             timeUntil: format,
                             timeUntilMs: time_until_ms,
+                            moreInfo: description,
                             logo: logo,
                         });
                     }

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -31,11 +31,15 @@ export default {
 
 			<b-button @click="$bvModal.show('community-events')" variant="dark" class="ml-2">
 				Events
-				<b-badge v-if="$refs.communityEvents?.events.length" variant="primary">
-					{{ $refs.communityEvents.events.length }}
-				</b-badge>
-				<b-badge v-if="$refs.communityEvents?.eventsNow" variant="danger">
-					{{ $refs.communityEvents.eventsNow }} live!
+				<b-badge v-if="$refs.communityEvents?.events.length > 0" variant="danger">
+					<span v-if="$refs.communityEvents?.eventsNow">
+						<b-icon icon="alarm"/>
+						{{ $refs.communityEvents.eventsNow }}
+					</span>
+					<span v-if="$refs.communityEvents?.eventsFuture">
+						<b-icon icon="calendar-plus"/>
+						{{ $refs.communityEvents.eventsFuture }}
+					</span>
 				</b-badge>
 			</b-button>
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.151'
+__version__ = '0.0.152'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
- Better event notifications
    - Events happening now and events happening in the future have their own counts and icons
    - Most of the time only the future event count/icon will be present, so having the extra distinction when there's something going on _right now_ might be beneficial
- Add support for loading tournament logos
    - This will help differentiate at a glance between different tournaments
- Add a "More info" link which will link to the tournament info doc provided in the description of the event

![image](https://github.com/RLBot/RLBotGUI/assets/35614515/3abbcfb7-3912-48c9-a5da-d9d2e7d92b42)
![image](https://github.com/RLBot/RLBotGUI/assets/35614515/13a26352-d4b3-46aa-8f8b-61eb73a4b7da)
