### PR TITLE
fix greenlet DLL issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ rlbot==1.*
 # This will cause pip to auto-upgrade and stop scaring people with warning messages
 pip
 
-gevent
+gevent<22
 eel>=0.12
 PyQt5


### PR DESCRIPTION
There is an issue with using greenlet v2+ if you do not have the c++ redistributable installed. it causes an error on trying to start rlbotgui that ends with:

>    from ._greenlet import _C_API # pylint:disable=no-name-in-module
> ImportError: DLL load failed: The specified module could not be found.

The latest gevent pins greenlet to 2+, and rlbotgui has in its requirements to just get any gevent version. So this problem likely has affected some people since the first gevent v22 was pushed to pypi on Oct 8 2022. 
The versions of gevent prior to 22 pin greenlet to be less than 2 - for example in v21.12 it is (<2.0,>=1.1.3)

This fix will pin gevent to be less than v22.

To replicate the issue and test the fix just try to install rlbotgui on any fresh VM or Windows sandbox mode.