### PR TITLE
Use absolute path for ping in alt installer

### DIFF
--- a/alternative-install/RLBotGUI.bat
+++ b/alternative-install/RLBotGUI.bat
@@ -35,7 +35,7 @@ call .\venv\Scripts\activate.bat
 
 rem We ping google.com to see if we have an internet connection
 rem We then store the output of the command to nul which prevents the command from printing to the console
-ping -n 1 google.com > nul
+%WINDIR%\system32\ping -n 1 google.com > nul
 if %errorlevel% == 0 (
   echo Installing / upgrading RLBot components...
   python -m pip install --upgrade pip


### PR DESCRIPTION
Some users do not have C:\System32 in their PATH environment variable. Ping is in C:\System32 so these users are unable to install the required dependencies using the alternative installer.
All Windows machines are supposed to have ping, so we use an absolute path to it for users that do not have it in their environment variables.
I've tested this alternative installer on my machine with C:\System32 removed from my PATH and it works.

This is a part of #219.