### PR TITLE
Fix requirements for Python 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.154'
+__version__ = '0.0.155'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()
@@ -12,13 +12,13 @@ setuptools.setup(
     # already bundling those in the pynsist installer.
     # We'll go ahead and list some packages needed by bots in the bot pack, though.
     install_requires=[
-        'numba==0.55.1',
+        'numba',
         'scipy',
         'numpy',
         'RLUtilities',  # Used by Snek
         'websockets',  # Needed for scratch bots
         'selenium',  # Needed for scratch bots
-        'PyQt5==5.15.*'  # Used for settings and file pickers currently.
+        'PyQt5'  # Used for settings and file pickers currently.
         ],
     version=__version__,
     description='A streamlined user interface for RLBot.',

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.md", "r") as readme_file:
 setuptools.setup(
     name='rlbot_gui',
     packages=setuptools.find_packages(),
+    python_requires='>=3.11',
     # It actually requires 'gevent', 'eel', 'PyQt5', but that messes up the install for some people and we're
     # already bundling those in the pynsist installer.
     # We'll go ahead and list some packages needed by bots in the bot pack, though.


### PR DESCRIPTION
https://github.com/RLBot/RLBot/issues/623 and https://github.com/RLBot/RLBot/issues/627 are related

New minimum Python version is Python 3.11 so older versions of Python install the right packages and we don't break install that might still work