### PR TITLE
Add favorites

### DIFF
--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -34,7 +34,7 @@ from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, star
 from rlbot_gui.match_runner.custom_maps import find_all_custom_maps
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
 from rlbot_gui.persistence.settings import load_settings, BOT_FOLDER_SETTINGS_KEY, MATCH_SETTINGS_KEY, \
-    LAUNCHER_SETTINGS_KEY, TEAM_SETTINGS_KEY, load_launcher_settings, launcher_preferences_from_map
+    LAUNCHER_SETTINGS_KEY, TEAM_SETTINGS_KEY, load_launcher_settings, launcher_preferences_from_map, FAVORITES_KEY
 from rlbot import gateway_util
 
 #### LOAD JUST TO EXPOSE STORY_MODE
@@ -228,6 +228,19 @@ def save_launcher_settings(launcher_settings_map):
 def save_team_settings(blue_bots, orange_bots):
     settings = load_settings()
     settings.setValue(TEAM_SETTINGS_KEY, {"blue_team": blue_bots, "orange_team": orange_bots})
+
+
+@eel.expose
+def get_favorite_runnables():
+    settings = load_settings()
+    favorite_runnables = settings.value(FAVORITES_KEY, type=list)
+    return favorite_runnables if favorite_runnables else []
+
+
+@eel.expose
+def save_favorite_runnables(runnables):
+    settings = load_settings()
+    settings.setValue(FAVORITES_KEY, runnables)
 
 
 @eel.expose

--- a/rlbot_gui/gui.py
+++ b/rlbot_gui/gui.py
@@ -34,7 +34,7 @@ from rlbot_gui.match_runner.match_runner import hot_reload_bots, shut_down, star
 from rlbot_gui.match_runner.custom_maps import find_all_custom_maps
 from rlbot_gui.type_translation.packet_translation import convert_packet_to_dict
 from rlbot_gui.persistence.settings import load_settings, BOT_FOLDER_SETTINGS_KEY, MATCH_SETTINGS_KEY, \
-    LAUNCHER_SETTINGS_KEY, TEAM_SETTINGS_KEY, load_launcher_settings, launcher_preferences_from_map, FAVORITES_KEY
+    LAUNCHER_SETTINGS_KEY, TEAM_SETTINGS_KEY, FAVORITES_KEY, load_launcher_settings, launcher_preferences_from_map
 from rlbot import gateway_util
 
 #### LOAD JUST TO EXPOSE STORY_MODE

--- a/rlbot_gui/gui/js/bot-card-vue.js
+++ b/rlbot_gui/gui/js/bot-card-vue.js
@@ -8,6 +8,7 @@ export default {
 	props: {
 		bot: Object,
 		disabled: Boolean,
+		favorited: Boolean,
 		draggable: {
 			type: Boolean,
 			default: true,
@@ -15,7 +16,7 @@ export default {
 	},
 	template: /*html*/`
 		<draggable v-model="draggableModel" :options="draggableOptions" style="display: inline;">
-			<runnable-card :runnable="bot" v-bind="[$props,$attrs]" :class="{draggable: draggable}" @click="$emit('click')">
+			<runnable-card :runnable="bot" v-bind="[$props,$attrs]" :class="{draggable: draggable}" :favorited="favorited" @click="$emit('click')">
 		</draggable>
 	`,
 	computed: {

--- a/rlbot_gui/gui/js/bot-pool-vue.js
+++ b/rlbot_gui/gui/js/bot-pool-vue.js
@@ -10,7 +10,7 @@ export default {
 		'script-card': ScriptCard,
 		'script-dependencies': ScriptDependencies,
 	},
-	props: ['bots', 'scripts', 'display-human'],
+	props: ['bots', 'scripts', 'display-human', 'favorites'],
 	template: /*html*/`
 		<div class="p-1">
 			<b-form inline class="mb-2">
@@ -33,7 +33,7 @@ export default {
 			</b-form>
 	
 			<div class="overflow-auto">
-				<bot-card v-for="bot in bots" :bot="bot" v-show="passesFilter(bot)" @click="$emit('bot-clicked', bot)"/>
+				<bot-card v-for="bot in bots" :bot="bot" v-show="passesFilter(bot)" @click="$emit('bot-clicked', bot)" :favorited="favorites.includes(bot.path)" />
 	
 				<span v-if="displayedBotsCount + displayedScriptsCount === 0">
 					No bots available for this category.
@@ -41,7 +41,7 @@ export default {
 	
 				<div v-if="displayedScriptsCount > 0" class="scripts-header">Scripts</div>
 	
-				<script-card v-for="script in scripts" :script="script" v-show="passesFilter(script)"/>
+				<script-card v-for="script in scripts" :script="script" v-show="passesFilter(script)" :favorited="favorites.includes(script.path)"/>
 				
 				<script-dependencies :bots="bots" :scripts="scripts"
 					v-if="secondaryCategorySelected.displayScriptDependencies"
@@ -83,6 +83,10 @@ export default {
 			// except for the script dependencies, where all scripts are displayed already
 			if (runnable.type === 'script' && !category.displayScriptDependencies && runnable.enabled)
 				return true;
+
+			if (category && category.favorites) {
+				return this.favorites.includes(runnable.path)
+			}
 
 			let allowedTag = runnable.type === 'script' ? category.scripts : category.bots;
 			if (allowedTag) {

--- a/rlbot_gui/gui/js/categories.js
+++ b/rlbot_gui/gui/js/categories.js
@@ -70,4 +70,12 @@ export default {
             },
         ],
     },
+    favorites: {
+        name: "Favorites",
+        categories: [
+            {
+                favorites: true,
+            },
+        ],
+    },
 };

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -257,11 +257,15 @@ export default {
 
 		<b-modal id="bot-info-modal" size="xl" :title="activeBot.name" v-if="activeBot && activeBot.info" hide-footer centered>
 			<template #modal-title="{ close }">
-				<b-button v-if="activeBot.path" variant="outline-primary" class="icon-button" @click="toggleFavoriteRunnable(activeBot)">
-					<b-icon v-if="favoritesPool.includes(activeBot.path)"  icon="star-fill" variant="warning" />
-					<b-icon v-if="!favoritesPool.includes(activeBot.path)" icon="star" />
-				</b-button>
-				{{activeBot.name}}
+				<div class="d-flex align-items-center">
+					{{activeBot.name}}
+					<b-button v-if="activeBot.path" variant="outline-warning" class="icon-button" @click="toggleFavoriteRunnable(activeBot)"
+						v-b-tooltip.hover title="Toggle bot as favorite"
+					>
+						<b-icon v-if="favoritesPool.includes(activeBot.path)" icon="star-fill" />
+						<b-icon v-else icon="star" />
+					</b-button>
+				</div>
 			</template>
 
 			<img v-if="activeBot.logo" class="bot-logo" v-bind:src="activeBot.logo">

--- a/rlbot_gui/gui/js/main-vue.js
+++ b/rlbot_gui/gui/js/main-vue.js
@@ -259,10 +259,10 @@ export default {
 			<template #modal-title="{ close }">
 				<div class="d-flex align-items-center">
 					{{activeBot.name}}
-					<b-button v-if="activeBot.path" variant="outline-warning" class="icon-button" @click="toggleFavoriteRunnable(activeBot)"
+					<b-button v-if="activeBot.path" variant="outline-primary" class="icon-button" @click="toggleFavoriteRunnable(activeBot)"
 						v-b-tooltip.hover title="Toggle bot as favorite"
 					>
-						<b-icon v-if="favoritesPool.includes(activeBot.path)" icon="star-fill" />
+						<b-icon v-if="favoritesPool.includes(activeBot.path)" icon="star-fill" variant="warning" />
 						<b-icon v-else icon="star" />
 					</b-button>
 				</div>

--- a/rlbot_gui/gui/js/runnable-card-vue.js
+++ b/rlbot_gui/gui/js/runnable-card-vue.js
@@ -5,6 +5,7 @@ export default {
 		disabled: Boolean,
 		removable: Boolean,
 		hidewarning: Boolean,
+		favorited: Boolean,
 	},
 	template: /*html*/`
 		<b-card class="bot-card" @click="disabled || $emit('click')" :class="{disabled: disabled}">
@@ -19,6 +20,8 @@ export default {
 					</span>
 				</span>
 			</slot>
+			
+			<b-icon v-if="favorited" icon="star-fill" variant="warning" style="margin-left: 0.33em"></b-icon>
 
 			<b-button size="sm" class="icon-button warning-icon" v-if="runnable.warn && !hidewarning" variant="outline-warning"
 						@click.stop="$store.commit('setActiveBot', runnable)" v-b-modal.language-warning-modal>

--- a/rlbot_gui/gui/js/script-card-vue.js
+++ b/rlbot_gui/gui/js/script-card-vue.js
@@ -2,12 +2,16 @@ import RunnableCard from './runnable-card-vue.js'
 
 export default {
 	name: 'script-card',
-	props: ['script', 'disabled'],
+	props: {
+		script: Object,
+		disabled: Boolean,
+		favorited: Boolean,
+	},
 	components: {
 		'runnable-card': RunnableCard,
 	},
 	template: `
-		<runnable-card :runnable="script" class="script-card" :disabled="disabled">
+		<runnable-card :runnable="script" class="script-card" :disabled="disabled" :favorited="favorited">
 			<b-form inline>
 				<b-form-checkbox v-model="script.enabled" class="script-switch" switch :disabled="disabled">
 					<img :src="script.logo">

--- a/rlbot_gui/persistence/settings.py
+++ b/rlbot_gui/persistence/settings.py
@@ -5,6 +5,7 @@ BOT_FOLDER_SETTINGS_KEY = 'bot_folder_settings'
 MATCH_SETTINGS_KEY = 'match_settings'
 LAUNCHER_SETTINGS_KEY = 'launcher_settings'
 TEAM_SETTINGS_KEY = 'team_settings'
+FAVORITES_KEY = 'favorite_runnables'
 
 
 def load_settings() -> QSettings:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-__version__ = '0.0.160'
+__version__ = '0.0.161'
 
 with open("README.md", "r") as readme_file:
     long_description = readme_file.read()


### PR DESCRIPTION
Changes:
- Bots and scripts can now be saved as favorites.
  - The button to do so is in the info modal. Clicking the button again will remove the bot/script from favorites.
  - Favorited bots/scripts show a star next to their name.
- A new Favorites category shows favorited bots/scripts.

![image](https://github.com/user-attachments/assets/dd3df8ff-599a-4022-ac52-077d9f09b73d)

![image](https://github.com/user-attachments/assets/ed6cf83f-e6f5-45ff-acec-f19d6ca6766d)

Things I'd like a second opinion on:
- Is the favorite button too hidden with its current position (next to name in info modal)? I could move it to the button next to "Edit Appearance".
- Should the star also be displayed on the bot card in the teams?

Please test that this work for you, Mr Reviewer. I don't have many bots/scripts on this computer to test with.